### PR TITLE
feat(fe): use pinia as client store

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "pinia": "^2.0.13",
     "vue": "^3.2.31",
     "vue-router": "^4.0.14"
   },

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
+import { createPinia } from 'pinia'
 import routes from 'virtual:generated-pages'
 import App from './App.vue'
 
@@ -11,4 +12,5 @@ const router = createRouter({
   routes
 })
 app.use(router)
+app.use(createPinia())
 app.mount('#app')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,7 @@ importers:
       '@vitejs/plugin-vue': ^2.2.2
       '@vue/tsconfig': ^0.1.3
       autoprefixer: ^10.4.4
+      pinia: ^2.0.13
       postcss: ^8.4.12
       tailwindcss: ^3.0.23
       typescript: ^4.6.2
@@ -89,6 +90,7 @@ importers:
       vue-router: ^4.0.14
       vue-tsc: ^0.31.4
     dependencies:
+      pinia: 2.0.13_typescript@4.6.2+vue@3.2.31
       vue: 3.2.31
       vue-router: 4.0.14_vue@3.2.31
     devDependencies:
@@ -5105,6 +5107,24 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
+  /pinia/2.0.13_typescript@4.6.2+vue@3.2.31:
+    resolution: {integrity: sha512-B7rSqm1xNpwcPMnqns8/gVBfbbi7lWTByzS6aPZ4JOXSJD4Y531rZHDCoYWBwLyHY/8hWnXljgiXp6rRyrofcw==}
+    peerDependencies:
+      '@vue/composition-api': ^1.4.0
+      typescript: '>=4.4.4'
+      vue: ^2.6.14 || ^3.2.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/devtools-api': 6.1.4
+      typescript: 4.6.2
+      vue: 3.2.31
+      vue-demi: 0.12.5_vue@3.2.31
+    dev: false
+
   /pirates/4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
     engines: {node: '>= 6'}
@@ -6492,6 +6512,21 @@ packages:
       vscode-pug-languageservice: 0.31.4
       vscode-typescript-languageservice: 0.31.4
     dev: true
+
+  /vue-demi/0.12.5_vue@3.2.31:
+    resolution: {integrity: sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      vue: 3.2.31
+    dev: false
 
   /vue-eslint-parser/8.3.0_eslint@8.12.0:
     resolution: {integrity: sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==}


### PR DESCRIPTION
### Description
pinia를 client store로 사용합니다. 
현재 store로 사용할만한 예제가 없어서 포함하지 않았지만, modular architecture pattern을 따르기 위해서는 모듈 안 stores 디렉토리를 만들고나서 client store를 정의합니다. [Example](https://github.com/shamscorner/vitesse-stackter-clean-architect/blob/de720ff76b89d01af235f53fc4fb01d160422396/src/orders/stores/order.ts)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

closes #23

### Additional context
SSR을 사용할 경우 세팅에 있어서 변경이 필요합니다.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
