### PR TITLE
chore(be): sync schema.prisma with ERD diagram

### DIFF
--- a/backend/prisma/migrations/20220620162501_basic_plan/migration.sql
+++ b/backend/prisma/migrations/20220620162501_basic_plan/migration.sql
@@ -1,0 +1,369 @@
+/*
+  Warnings:
+
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "User";
+
+-- CreateTable
+CREATE TABLE "user" (
+    "id" SERIAL NOT NULL,
+    "username" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "has_email_authenticated" BOOLEAN NOT NULL DEFAULT false,
+    "last_login" TIMESTAMP(3) NOT NULL,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_profile" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "real_name" TEXT,
+    "major" TEXT,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_profile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_group" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "group_id" INTEGER NOT NULL,
+    "is_registered" BOOLEAN NOT NULL DEFAULT false,
+    "is_group_manager" BOOLEAN NOT NULL DEFAULT false,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_group_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "group" (
+    "id" SERIAL NOT NULL,
+    "created_by_id" INTEGER NOT NULL,
+    "group_name" TEXT NOT NULL,
+    "private" BOOLEAN NOT NULL DEFAULT false,
+    "invitation_code" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "group_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "group_notice" (
+    "id" SERIAL NOT NULL,
+    "group_id" INTEGER NOT NULL,
+    "notice_id" INTEGER NOT NULL,
+
+    CONSTRAINT "group_notice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notice" (
+    "id" SERIAL NOT NULL,
+    "created_by_id" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "visible" BOOLEAN NOT NULL DEFAULT true,
+    "top_fixed" BOOLEAN NOT NULL DEFAULT false,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "problem" (
+    "id" SERIAL NOT NULL,
+    "created_by_id" INTEGER NOT NULL,
+    "group_id" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "input_description" TEXT NOT NULL,
+    "output_description" TEXT NOT NULL,
+    "hint" TEXT NOT NULL,
+    "languages" JSONB NOT NULL,
+    "time_limit" INTEGER NOT NULL,
+    "memory_limit" INTEGER NOT NULL,
+    "difficulty" TEXT NOT NULL,
+    "source" JSONB NOT NULL,
+    "shared" BOOLEAN NOT NULL DEFAULT false,
+    "submission_num" INTEGER NOT NULL DEFAULT 0,
+    "accepted_num" INTEGER NOT NULL DEFAULT 0,
+    "score" INTEGER NOT NULL DEFAULT 0,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "problem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "problem_testcase" (
+    "id" SERIAL NOT NULL,
+    "problem_id" INTEGER NOT NULL,
+    "input" TEXT NOT NULL,
+    "output" TEXT NOT NULL,
+    "score" INTEGER NOT NULL DEFAULT 0,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "problem_testcase_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "problem_tag" (
+    "id" SERIAL NOT NULL,
+    "problem_id" INTEGER NOT NULL,
+    "tag_id" INTEGER NOT NULL,
+
+    CONSTRAINT "problem_tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tag" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "visible" BOOLEAN NOT NULL DEFAULT true,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contest" (
+    "id" SERIAL NOT NULL,
+    "created_by_id" INTEGER NOT NULL,
+    "group_id" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "start_time" TIMESTAMP(3) NOT NULL,
+    "end_time" TIMESTAMP(3) NOT NULL,
+    "visible" BOOLEAN NOT NULL DEFAULT true,
+    "is_rank_visible" BOOLEAN NOT NULL DEFAULT true,
+    "type" TEXT NOT NULL DEFAULT E'ACM',
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contest_notice" (
+    "id" SERIAL NOT NULL,
+    "contest_id" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "problem_id" TEXT NOT NULL,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contest_notice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contest_problem" (
+    "id" SERIAL NOT NULL,
+    "contest_id" INTEGER NOT NULL,
+    "problem_id" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL DEFAULT 0,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contest_problem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contest_record" (
+    "id" SERIAL NOT NULL,
+    "contest_id" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "rank" INTEGER NOT NULL,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contest_record_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contest_rank_acm" (
+    "id" SERIAL NOT NULL,
+    "contest_id" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "accepted_problem_num" INTEGER NOT NULL DEFAULT 0,
+    "total_penalty" INTEGER NOT NULL DEFAULT 0,
+    "submission_info" JSONB,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contest_rank_acm_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "workbook" (
+    "id" SERIAL NOT NULL,
+    "created_by_id" INTEGER NOT NULL,
+    "group_id" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "start_time" TIMESTAMP(3) NOT NULL,
+    "end_time" TIMESTAMP(3) NOT NULL,
+    "visible" BOOLEAN NOT NULL DEFAULT true,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "workbook_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "workbook_problem" (
+    "id" SERIAL NOT NULL,
+    "workbook_id" INTEGER NOT NULL,
+    "problem_id" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL DEFAULT 0,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "workbook_problem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "submission" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "problem_id" INTEGER NOT NULL,
+    "contest_id" INTEGER,
+    "workbook_id" INTEGER,
+    "code" TEXT NOT NULL,
+    "language" TEXT NOT NULL,
+    "shared" BOOLEAN NOT NULL DEFAULT false,
+    "ip_addr" TEXT NOT NULL,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "submission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "submssion_result" (
+    "id" SERIAL NOT NULL,
+    "submission_id" INTEGER NOT NULL,
+    "result" TEXT NOT NULL,
+    "accepted_num" INTEGER NOT NULL,
+    "total_score" INTEGER NOT NULL,
+    "create_time" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "submssion_result_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_username_key" ON "user"("username");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_email_key" ON "user"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_profile_user_id_key" ON "user_profile"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "user_profile" ADD CONSTRAINT "user_profile_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_group" ADD CONSTRAINT "user_group_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_group" ADD CONSTRAINT "user_group_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "group"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "group" ADD CONSTRAINT "group_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "group_notice" ADD CONSTRAINT "group_notice_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "group"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "group_notice" ADD CONSTRAINT "group_notice_notice_id_fkey" FOREIGN KEY ("notice_id") REFERENCES "notice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notice" ADD CONSTRAINT "notice_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "problem" ADD CONSTRAINT "problem_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "problem" ADD CONSTRAINT "problem_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "group"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "problem_testcase" ADD CONSTRAINT "problem_testcase_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "problem_tag" ADD CONSTRAINT "problem_tag_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "problem_tag" ADD CONSTRAINT "problem_tag_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "tag"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest" ADD CONSTRAINT "contest_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest" ADD CONSTRAINT "contest_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "group"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest_notice" ADD CONSTRAINT "contest_notice_contest_id_fkey" FOREIGN KEY ("contest_id") REFERENCES "contest"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest_problem" ADD CONSTRAINT "contest_problem_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest_problem" ADD CONSTRAINT "contest_problem_contest_id_fkey" FOREIGN KEY ("contest_id") REFERENCES "contest"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest_record" ADD CONSTRAINT "contest_record_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest_record" ADD CONSTRAINT "contest_record_contest_id_fkey" FOREIGN KEY ("contest_id") REFERENCES "contest"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest_rank_acm" ADD CONSTRAINT "contest_rank_acm_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contest_rank_acm" ADD CONSTRAINT "contest_rank_acm_contest_id_fkey" FOREIGN KEY ("contest_id") REFERENCES "contest"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "workbook" ADD CONSTRAINT "workbook_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "workbook" ADD CONSTRAINT "workbook_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "group"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "workbook_problem" ADD CONSTRAINT "workbook_problem_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "workbook_problem" ADD CONSTRAINT "workbook_problem_workbook_id_fkey" FOREIGN KEY ("workbook_id") REFERENCES "workbook"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "submission" ADD CONSTRAINT "submission_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "submission" ADD CONSTRAINT "submission_problem_id_fkey" FOREIGN KEY ("problem_id") REFERENCES "problem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "submission" ADD CONSTRAINT "submission_contest_id_fkey" FOREIGN KEY ("contest_id") REFERENCES "contest"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "submission" ADD CONSTRAINT "submission_workbook_id_fkey" FOREIGN KEY ("workbook_id") REFERENCES "workbook"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "submssion_result" ADD CONSTRAINT "submssion_result_submission_id_fkey" FOREIGN KEY ("submission_id") REFERENCES "submission"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,6 +11,312 @@ datasource db {
 }
 
 model User {
-  id    Int    @id @default(autoincrement())
-  email String @unique
+  id                      Int      @id @default(autoincrement())
+  username                String   @unique
+  password                String
+  role                    String
+  email                   String   @unique
+  has_email_authenticated Boolean  @default(false)
+  last_login              DateTime
+  create_time             DateTime @default(now())
+  update_time             DateTime @updatedAt
+
+  UserProfile    UserProfile?
+  UserGroup      UserGroup[]
+  Group          Group[]
+  Notice         Notice[]
+  Problem        Problem[]
+  Contest        Contest[]
+  ContestRecord  ContestRecord[]
+  ContestRankACM ContestRankACM[]
+  Workbook       Workbook[]
+
+  @@map("user")
+}
+
+model UserProfile {
+  id          Int      @id @default(autoincrement())
+  user        User     @relation(fields: [user_id], references: [id])
+  user_id     Int      @unique
+  real_name   String?
+  major       String?
+  create_time DateTime @default(now())
+  update_time DateTime @updatedAt
+
+  @@map("user_profile")
+}
+
+model UserGroup {
+  id               Int      @id @default(autoincrement())
+  user             User     @relation(fields: [user_id], references: [id])
+  user_id          Int
+  group            Group    @relation(fields: [group_id], references: [id])
+  group_id         Int
+  is_registered    Boolean  @default(false)
+  is_group_manager Boolean  @default(false)
+  create_time      DateTime @default(now())
+  update_time      DateTime @updatedAt
+
+  @@map("user_group")
+}
+
+model Group {
+  id              Int      @id @default(autoincrement())
+  created_by      User     @relation(fields: [created_by_id], references: [id])
+  created_by_id   Int
+  group_name      String
+  private         Boolean  @default(false)
+  // 생성시 자동 발급
+  invitation_code String
+  description     String
+  create_time     DateTime @default(now())
+  update_time     DateTime @updatedAt
+
+  UserGroup   UserGroup[]
+  GroupNotice GroupNotice[]
+  Problem     Problem[]
+  Contest     Contest[]
+  Workbook    Workbook[]
+
+  @@map("group")
+}
+
+model GroupNotice {
+  id        Int    @id @default(autoincrement())
+  group     Group  @relation(fields: [group_id], references: [id])
+  group_id  Int
+  notice    Notice @relation(fields: [notice_id], references: [id])
+  notice_id Int
+
+  @@map("group_notice")
+}
+
+model Notice {
+  id            Int      @id @default(autoincrement())
+  created_by    User     @relation(fields: [created_by_id], references: [id])
+  created_by_id Int
+  content       String
+  visible       Boolean  @default(true)
+  top_fixed     Boolean  @default(false)
+  create_time   DateTime @default(now())
+  update_time   DateTime @updatedAt
+
+  GroupNotice GroupNotice[]
+
+  @@map("notice")
+}
+
+model Problem {
+  id                 Int      @id @default(autoincrement())
+  created_by         User     @relation(fields: [created_by_id], references: [id])
+  created_by_id      Int
+  group              Group    @relation(fields: [group_id], references: [id])
+  group_id           Int
+  title              String
+  description        String
+  input_description  String
+  output_description String
+  hint               String
+  languages          Json
+  time_limit         Int
+  memory_limit       Int
+  difficulty         String
+  source             Json
+  shared             Boolean  @default(false)
+  submission_num     Int      @default(0)
+  accepted_num       Int      @default(0)
+  score              Int      @default(0)
+  create_time        DateTime @default(now())
+  update_time        DateTime @updatedAt
+
+
+  ProblemTestcase ProblemTestcase[]
+  ProblemTag      ProblemTag[]
+  ContestProblem  ContestProblem[]
+  WorkbookProblem WorkbookProblem[]
+  Submission      Submission[]
+
+  @@map("problem")
+}
+
+model ProblemTestcase {
+  id          Int      @id @default(autoincrement())
+  problem     Problem  @relation(fields: [problem_id], references: [id])
+  problem_id  Int
+  input       String
+  output      String
+  score       Int      @default(0)
+  create_time DateTime @default(now())
+  update_time DateTime @updatedAt
+
+  @@map("problem_testcase")
+}
+
+model ProblemTag {
+  id         Int     @id @default(autoincrement())
+  problem    Problem @relation(fields: [problem_id], references: [id])
+  problem_id Int
+  tag        Tag     @relation(fields: [tag_id], references: [id])
+  tag_id     Int
+
+  @@map("problem_tag")
+}
+
+model Tag {
+  id          Int      @id @default(autoincrement())
+  name        String
+  type        String
+  visible     Boolean  @default(true)
+  create_time DateTime @default(now())
+  update_time DateTime @updatedAt
+
+  ProblemTag ProblemTag[]
+
+  @@map("tag")
+}
+
+model Contest {
+  id              Int      @id @default(autoincrement())
+  created_by      User     @relation(fields: [created_by_id], references: [id])
+  created_by_id   Int
+  group           Group    @relation(fields: [group_id], references: [id])
+  group_id        Int
+  title           String
+  description     String
+  start_time      DateTime
+  end_time        DateTime
+  visible         Boolean  @default(true)
+  is_rank_visible Boolean  @default(true)
+  type            String   @default("ACM")
+  create_time     DateTime @default(now())
+  update_time     DateTime @updatedAt
+
+  ContestNotice  ContestNotice[]
+  ContestProblem ContestProblem[]
+  ContestRecord  ContestRecord[]
+  ContestRankACM ContestRankACM[]
+
+  Submission Submission[]
+
+  @@map("contest")
+}
+
+model ContestNotice {
+  id          Int      @id @default(autoincrement())
+  contest     Contest  @relation(fields: [contest_id], references: [id])
+  contest_id  Int
+  title       String
+  description String
+  problem_id  String
+  create_time DateTime @default(now())
+  update_time DateTime @updatedAt
+
+  @@map("contest_notice")
+}
+
+model ContestProblem {
+  id          Int      @id @default(autoincrement())
+  contest     Contest  @relation(fields: [contest_id], references: [id])
+  contest_id  Int
+  problem     Problem  @relation(fields: [problem_id], references: [id])
+  problem_id  Int
+  score       Int      @default(0)
+  create_time DateTime @default(now())
+  update_time DateTime @updatedAt
+
+  @@map("contest_problem")
+}
+
+model ContestRecord {
+  id          Int      @id @default(autoincrement())
+  contest     Contest  @relation(fields: [contest_id], references: [id])
+  contest_id  Int
+  user        User     @relation(fields: [user_id], references: [id])
+  user_id     Int
+  rank        Int
+  create_time DateTime @default(now())
+  update_time DateTime @updatedAt
+
+  @@map("contest_record")
+}
+
+model ContestRankACM {
+  id                   Int      @id @default(autoincrement())
+  contest              Contest  @relation(fields: [contest_id], references: [id])
+  contest_id           Int
+  user                 User     @relation(fields: [user_id], references: [id])
+  user_id              Int
+  accepted_problem_num Int      @default(0)
+  total_penalty        Int      @default(0)
+  submission_info      Json?
+  create_time          DateTime @default(now())
+  update_time          DateTime @updatedAt
+
+  @@map("contest_rank_acm")
+}
+
+model Workbook {
+  id            Int      @id @default(autoincrement())
+  created_by    User     @relation(fields: [created_by_id], references: [id])
+  created_by_id Int
+  group         Group    @relation(fields: [group_id], references: [id])
+  group_id      Int
+  title         String
+  description   String
+  start_time    DateTime
+  end_time      DateTime
+  visible       Boolean  @default(true)
+  create_time   DateTime @default(now())
+  update_time   DateTime @updatedAt
+
+  WorkbookProblem WorkbookProblem[]
+  Submission      Submission[]
+
+  @@map("workbook")
+}
+
+model WorkbookProblem {
+  id          Int      @id @default(autoincrement())
+  workbook    Workbook @relation(fields: [workbook_id], references: [id])
+  workbook_id Int
+  problem     Problem  @relation(fields: [problem_id], references: [id])
+  problem_id  Int
+  score       Int      @default(0)
+  create_time DateTime @default(now())
+  update_time DateTime @updatedAt
+
+  @@map("workbook_problem")
+}
+
+model Submission {
+  id          Int       @id @default(autoincrement())
+  problem     Problem   @relation(fields: [problem_id], references: [id])
+  problem_id  Int
+  contest     Contest?  @relation(fields: [contest_id], references: [id])
+  contest_id  Int?
+  workbook    Workbook? @relation(fields: [workbook_id], references: [id])
+  workbook_id Int?
+  code        String
+  language    String
+  shared      Boolean   @default(false)
+  ip_addr     String
+  create_time DateTime  @default(now())
+  update_time DateTime  @updatedAt
+
+  SubmissionResult SubmissionResult[]
+
+  @@map("submission")
+}
+
+model SubmissionResult {
+  id            Int        @id @default(autoincrement())
+  submission    Submission @relation(fields: [submission_id], references: [id])
+  submission_id Int
+  result        String
+  accepted_num  Int
+  total_score   Int
+  create_time   DateTime   @default(now())
+  update_time   DateTime   @updatedAt
+
+  @@map("submssion_result")
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   Workbook       Workbook[]
 
   @@map("user")
+  Submission Submission[]
 }
 
 model UserProfile {
@@ -62,7 +63,7 @@ model UserGroup {
 
 model Group {
   id              Int      @id @default(autoincrement())
-  created_by      User     @relation(fields: [created_by_id], references: [id])
+  created_by      User     @relation(fields: [created_by_id], references: [id], onDelete: SetNull)
   created_by_id   Int
   group_name      String
   private         Boolean  @default(false)
@@ -93,7 +94,7 @@ model GroupNotice {
 
 model Notice {
   id            Int      @id @default(autoincrement())
-  created_by    User     @relation(fields: [created_by_id], references: [id])
+  created_by    User     @relation(fields: [created_by_id], references: [id], onDelete: SetNull)
   created_by_id Int
   content       String
   visible       Boolean  @default(true)
@@ -108,7 +109,7 @@ model Notice {
 
 model Problem {
   id                 Int      @id @default(autoincrement())
-  created_by         User     @relation(fields: [created_by_id], references: [id])
+  created_by         User     @relation(fields: [created_by_id], references: [id], onDelete: SetNull)
   created_by_id      Int
   group              Group    @relation(fields: [group_id], references: [id])
   group_id           Int
@@ -177,7 +178,7 @@ model Tag {
 
 model Contest {
   id              Int      @id @default(autoincrement())
-  created_by      User     @relation(fields: [created_by_id], references: [id])
+  created_by      User     @relation(fields: [created_by_id], references: [id], onDelete: SetNull)
   created_by_id   Int
   group           Group    @relation(fields: [group_id], references: [id])
   group_id        Int
@@ -257,7 +258,7 @@ model ContestRankACM {
 
 model Workbook {
   id            Int      @id @default(autoincrement())
-  created_by    User     @relation(fields: [created_by_id], references: [id])
+  created_by    User     @relation(fields: [created_by_id], references: [id], onDelete: SetNull)
   created_by_id Int
   group         Group    @relation(fields: [group_id], references: [id])
   group_id      Int
@@ -290,6 +291,8 @@ model WorkbookProblem {
 
 model Submission {
   id          Int       @id @default(autoincrement())
+  user        User      @relation(fields: [user_id], references: [id])
+  user_id     Int
   problem     Problem   @relation(fields: [problem_id], references: [id])
   problem_id  Int
   contest     Contest?  @relation(fields: [contest_id], references: [id])

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -30,9 +30,9 @@ model User {
   ContestRecord  ContestRecord[]
   ContestRankACM ContestRankACM[]
   Workbook       Workbook[]
+  Submission     Submission[]
 
   @@map("user")
-  Submission Submission[]
 }
 
 model UserProfile {
@@ -196,8 +196,7 @@ model Contest {
   ContestProblem ContestProblem[]
   ContestRecord  ContestRecord[]
   ContestRankACM ContestRankACM[]
-
-  Submission Submission[]
+  Submission     Submission[]
 
   @@map("contest")
 }


### PR DESCRIPTION
### Description

기획 단계에서 도출된 [ERD diagram](https://www.erdcloud.com/d/jHCbTNnSieZSbPLDG)을 `schema.prisma`에 반영합니다.

Closes #56 

### Additional context

- `created_by` field는 `create_time`, `update_time`과 같은 metadata입니다. `OnDelete: SetNull` 옵션을 적용했습니다.
- [PostgreSQL과 Prisma model의 DB naming convention](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/use-custom-model-and-field-names)이 달라 `@@map` 을 사용해 table 이름을 직접 지정하였습니다.
- 지금까지 도출된 ERD diagram을 반영한 것으로 개발 과정에서 언제든지 수정될 수 있습니다.
- 문제은행 관련 테이블은 확정되지 않아 제외하였습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
