### PR TITLE
feat(fe): add pagetitle component

### DIFF
--- a/frontend/src/common/components/Atom/PageSubtitle.vue
+++ b/frontend/src/common/components/Atom/PageSubtitle.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+  text: string
+}>()
+</script>
+
+<template>
+  <div class="text-text-subtitle text-xl font-bold">{{ text }}</div>
+</template>

--- a/frontend/src/common/components/Atom/PageTitle.vue
+++ b/frontend/src/common/components/Atom/PageTitle.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+  text: string
+}>()
+</script>
+
+<template>
+  <div class="text-text-title text-3xl font-bold">{{ text }}</div>
+</template>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -26,7 +26,7 @@ module.exports = {
       red: '#ff6663',
       text: {
         title: '#7c7a7b',
-        subtitle: '#a13e51',
+        subtitle: '#173747',
         DEFAULT: '#212529'
       },
       slate: {


### PR DESCRIPTION
### Description
- PageTitle, PageSubtitle component 구현

closes #73 
closes #92 

#### 사용법
- 사용하려는 상위 컴포넌트에서 text props로 title 명을 전달해줍니다.


### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
