### PR TITLE
feat(fe): add tab component

### DIFF
--- a/frontend/src/common/components/Molecule/Tab.story.vue
+++ b/frontend/src/common/components/Molecule/Tab.story.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import Tab from './Tab.vue'
+
+const items = ['notice', 'contest', 'workbook', 'member']
+</script>
+
+<template>
+  <Story>
+    <Tab :items="items">
+      <template #notice>This is Notice Page</template>
+      <template #contest>This is Contest Page</template>
+      <template #workbook>This is Workbook Page</template>
+      <template #member>This is Member Page</template>
+    </Tab>
+    <h2 class="mt-8 mb-2 text-lg">* custom example</h2>
+    <Tab :items="items" color="#FF1993">
+      <template #notice>This is Notice Page</template>
+      <template #contest>This is Contest Page</template>
+      <template #workbook>This is Workbook Page</template>
+      <template #member>This is Member Page</template>
+    </Tab>
+  </Story>
+</template>

--- a/frontend/src/common/components/Molecule/Tab.story.vue
+++ b/frontend/src/common/components/Molecule/Tab.story.vue
@@ -6,18 +6,21 @@ const items = ['notice', 'contest', 'workbook', 'member']
 
 <template>
   <Story>
-    <Tab :items="items">
-      <template #notice>This is Notice Page</template>
-      <template #contest>This is Contest Page</template>
-      <template #workbook>This is Workbook Page</template>
-      <template #member>This is Member Page</template>
-    </Tab>
-    <h2 class="mt-8 mb-2 text-lg">* custom example</h2>
-    <Tab :items="items" color="#FF1993">
-      <template #notice>This is Notice Page</template>
-      <template #contest>This is Contest Page</template>
-      <template #workbook>This is Workbook Page</template>
-      <template #member>This is Member Page</template>
-    </Tab>
+    <Variant title="Default">
+      <Tab :items="items">
+        <template #notice>This is Notice Page</template>
+        <template #contest>This is Contest Page</template>
+        <template #workbook>This is Workbook Page</template>
+        <template #member>This is Member Page</template>
+      </Tab>
+    </Variant>
+    <Variant title="Custom">
+      <Tab :items="items" color="#FF1993">
+        <template #notice>This is Notice Page</template>
+        <template #contest>This is Contest Page</template>
+        <template #workbook>This is Workbook Page</template>
+        <template #member>This is Member Page</template>
+      </Tab>
+    </Variant>
   </Story>
 </template>

--- a/frontend/src/common/components/Molecule/Tab.vue
+++ b/frontend/src/common/components/Molecule/Tab.vue
@@ -47,5 +47,5 @@ const setHoverFalse = () => {
     </li>
   </ul>
 
-  <div class="m-4"><slot :name="`${activeItem}`"></slot></div>
+  <div class="m-4"><slot :name="activeItem" /></div>
 </template>

--- a/frontend/src/common/components/Molecule/Tab.vue
+++ b/frontend/src/common/components/Molecule/Tab.vue
@@ -31,23 +31,19 @@ const setHoverFalse = () => {
 </script>
 
 <template>
-  <div class="mx-auto w-4/5">
-    <div class="bg-gray h-px" />
-    <ul class="flex justify-center">
-      <li
-        v-for="item in items"
-        :key="item"
-        class="text-text-title mx-2 cursor-pointer p-2 text-xl"
-        :style="[hoverStyle(item), activeStyle(item)]"
-        @click="setActiveItem(item)"
-        @mouseover="setHoverItem(item)"
-        @mouseleave="setHoverFalse()"
-      >
-        {{ item.charAt(0).toUpperCase() + item.slice(1) }}
-      </li>
-    </ul>
-    <div class="bg-gray h-px" />
+  <ul class="border-gray mx-auto flex w-4/5 justify-center border-y">
+    <li
+      v-for="item in items"
+      :key="item"
+      class="text-text-title mx-2 cursor-pointer p-2 text-xl"
+      :style="[hoverStyle(item), activeStyle(item)]"
+      @click="setActiveItem(item)"
+      @mouseover="setHoverItem(item)"
+      @mouseleave="setHoverFalse()"
+    >
+      {{ item.charAt(0).toUpperCase() + item.slice(1) }}
+    </li>
+  </ul>
 
-    <div class="m-4"><slot :name="`${activeItem}`"></slot></div>
-  </div>
+  <div class="m-4"><slot :name="`${activeItem}`"></slot></div>
 </template>

--- a/frontend/src/common/components/Molecule/Tab.vue
+++ b/frontend/src/common/components/Molecule/Tab.vue
@@ -10,18 +10,19 @@ var activeItem = ref(props.items[0])
 var hoverItem = ref()
 const tabcolor = props.color ? props.color : '#8DC63F'
 
-const activeStyle = (item) => {
-  if (item == activeItem.value)
-    return `color: ${tabcolor}; border-bottom: 3px solid ${tabcolor};`
+const activeStyle = (item: string) => {
+  return item === activeItem.value
+    ? `color: ${tabcolor}; border-bottom: 3px solid ${tabcolor};`
+    : ''
 }
-const hoverStyle = (item) => {
-  if (item == hoverItem.value) return `color: ${tabcolor};`
+const hoverStyle = (item: string) => {
+  return item === hoverItem.value ? `color: ${tabcolor};` : ''
 }
 
-const setActiveItem = (item) => {
+const setActiveItem = (item: string) => {
   activeItem.value = item
 }
-const setHoverItem = (item) => {
+const setHoverItem = (item: string) => {
   hoverItem.value = item
 }
 const setHoverFalse = () => {
@@ -40,7 +41,7 @@ const setHoverFalse = () => {
         :style="[hoverStyle(item), activeStyle(item)]"
         @click="setActiveItem(item)"
         @mouseover="setHoverItem(item)"
-        @mouseleave="setHoverFalse(item)"
+        @mouseleave="setHoverFalse()"
       >
         {{ item.charAt(0).toUpperCase() + item.slice(1) }}
       </li>

--- a/frontend/src/common/components/Molecule/Tab.vue
+++ b/frontend/src/common/components/Molecule/Tab.vue
@@ -9,6 +9,8 @@ const props = defineProps<{
 const activeItem = ref(props.items[0])
 const hoverItem = ref()
 const tabcolor = props.color ? props.color : '#8DC63F'
+// TODO: use preset color
+// https://github.com/skkuding/next/pull/122#discussion_r928096433
 
 const activeStyle = (item: string) => {
   return item === activeItem.value

--- a/frontend/src/common/components/Molecule/Tab.vue
+++ b/frontend/src/common/components/Molecule/Tab.vue
@@ -6,8 +6,8 @@ const props = defineProps<{
   color?: string
 }>()
 
-var activeItem = ref(props.items[0])
-var hoverItem = ref()
+const activeItem = ref(props.items[0])
+const hoverItem = ref()
 const tabcolor = props.color ? props.color : '#8DC63F'
 
 const activeStyle = (item: string) => {

--- a/frontend/src/common/components/Molecule/Tab.vue
+++ b/frontend/src/common/components/Molecule/Tab.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const props = defineProps<{
+  items: string[]
+  color?: string
+}>()
+
+var activeItem = ref(props.items[0])
+var hoverItem = ref()
+const tabcolor = props.color ? props.color : '#8DC63F'
+
+const activeStyle = (item) => {
+  if (item == activeItem.value)
+    return `color: ${tabcolor}; border-bottom: 3px solid ${tabcolor};`
+}
+const hoverStyle = (item) => {
+  if (item == hoverItem.value) return `color: ${tabcolor};`
+}
+
+const setActiveItem = (item) => {
+  activeItem.value = item
+}
+const setHoverItem = (item) => {
+  hoverItem.value = item
+}
+const setHoverFalse = () => {
+  hoverItem.value = ''
+}
+</script>
+
+<template>
+  <div class="mx-auto w-4/5">
+    <div class="bg-gray h-px" />
+    <ul class="flex justify-center">
+      <li
+        v-for="item in items"
+        :key="item"
+        class="text-text-title mx-2 cursor-pointer p-2 text-xl"
+        :style="[hoverStyle(item), activeStyle(item)]"
+        @click="setActiveItem(item)"
+        @mouseover="setHoverItem(item)"
+        @mouseleave="setHoverFalse(item)"
+      >
+        {{ item.charAt(0).toUpperCase() + item.slice(1) }}
+      </li>
+    </ul>
+    <div class="bg-gray h-px" />
+
+    <div class="m-4"><slot :name="`${activeItem}`"></slot></div>
+  </div>
+</template>

--- a/frontend/src/common/components/Molecule/Tab.vue
+++ b/frontend/src/common/components/Molecule/Tab.vue
@@ -33,7 +33,7 @@ const setHoverFalse = () => {
 </script>
 
 <template>
-  <ul class="border-gray mx-auto flex w-4/5 justify-center border-y">
+  <ul class="border-gray flex w-full justify-center border-y">
     <li
       v-for="item in items"
       :key="item"


### PR DESCRIPTION
### Description
tab component 구현
<img width="952" alt="image" src="https://user-images.githubusercontent.com/75013515/178903983-47e87b54-37a1-4a92-a501-b858868b4148.png">

closes #77 

#### 사용법
1. tab 항목들을 items라는 props로 Tab component로 전달합니다.
2. tab의 색상을 커스텀하는 경우에는 color props로 전달합니다. 
   (group detail page에서는 해당 그룹에 해당하는 색깔에 맞춰 tab을 custom할 수 있습니다)
3. page에서 각 item에 해당하는 컴포넌트를 template으로 작성해주면 됩니다.
```
<Tab :items="items">
    <template #notice>
        notice
        <detail /> // notice 버튼을 누르면 detail component가 tab 밑에 표시됩니다.
    </template>
      <template #contest>
        contest
        <contest />
      </template>
</Tab>
```

### Additional context
tab component의 경우에는 사용자가 색상을 선택하여 적용해야 하기 때문에 동적으로 스타일을 적용할 수 있어야 합니다. 하지만 tailwind css에서는 동적으로 스타일을 적용할 수 없기 때문에 inline style으로 적용하였습니다. 
이 컴포넌트의 경우에는 사용자가 선택할 수 있는 모든 색상에 대해 config파일에 지정해둘 수 없기 때문에 safelist에 해당 스타일을 작성해두거나, 객체로 스타일을 적용하는 경우는 불가능하였습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
