### PR TITLE
feat(fe): add progress card component

### DIFF
--- a/frontend/src/common/components/Molecule/ProgressCard.story.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.story.vue
@@ -9,8 +9,8 @@ import ProgressCard from './ProgressCard.vue'
       header="updated 3.30"
       description="프로그래밍대회 기출문제 입니다."
       type="problem"
-      total="10"
-      complete="6"
+      :total="10"
+      :complete="6"
     />
     <h2 class="mt-8 mb-2 text-lg">Another Example</h2>
     <ProgressCard
@@ -18,8 +18,8 @@ import ProgressCard from './ProgressCard.vue'
       header="updated 3.30"
       description="프로그래밍대회 기출문제 입니다."
       type="score"
-      total="100"
-      complete="80"
+      :total="100"
+      :complete="80"
       color="#FFC3DA"
     />
   </Story>

--- a/frontend/src/common/components/Molecule/ProgressCard.story.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.story.vue
@@ -8,7 +8,6 @@ import ProgressCard from './ProgressCard.vue'
       title="프로그래밍대회"
       header="updated 3.30"
       description="프로그래밍대회 기출문제 입니다."
-      type="problem"
       :total="10"
       :complete="6"
     />
@@ -17,9 +16,9 @@ import ProgressCard from './ProgressCard.vue'
       title="프로그래밍대회"
       header="updated 3.30"
       description="프로그래밍대회 기출문제 입니다."
-      type="score"
       :total="100"
       :complete="80"
+      progress-text="problems"
       color="#FFC3DA"
     />
   </Story>

--- a/frontend/src/common/components/Molecule/ProgressCard.story.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.story.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import ProgressCard from './ProgressCard.vue'
+</script>
+
+<template>
+  <Story>
+    <ProgressCard
+      title="프로그래밍대회"
+      header="updated 3.30"
+      description="프로그래밍대회 기출문제 입니다."
+      type="problem"
+      total="10"
+      complete="6"
+    />
+    <h2 class="mt-8 mb-2 text-lg">Another Example</h2>
+    <ProgressCard
+      title="프로그래밍대회"
+      header="updated 3.30"
+      description="프로그래밍대회 기출문제 입니다."
+      type="score"
+      total="100"
+      complete="80"
+      color="#FFC3DA"
+    />
+  </Story>
+</template>

--- a/frontend/src/common/components/Molecule/ProgressCard.story.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.story.vue
@@ -4,22 +4,25 @@ import ProgressCard from './ProgressCard.vue'
 
 <template>
   <Story>
-    <ProgressCard
-      title="프로그래밍대회"
-      header="updated 3.30"
-      description="프로그래밍대회 기출문제 입니다."
-      :total="10"
-      :complete="6"
-    />
-    <h2 class="mt-8 mb-2 text-lg">Another Example</h2>
-    <ProgressCard
-      title="프로그래밍대회"
-      header="updated 3.30"
-      description="프로그래밍대회 기출문제 입니다."
-      :total="100"
-      :complete="80"
-      progress-text="problems"
-      color="#FFC3DA"
-    />
+    <Variant title="Default">
+      <ProgressCard
+        title="프로그래밍대회"
+        header="updated 3.30"
+        description="프로그래밍대회 기출문제 입니다."
+        :total="10"
+        :complete="6"
+      />
+    </Variant>
+    <Variant title="Custom">
+      <ProgressCard
+        title="프로그래밍대회"
+        header="updated 3.30"
+        description="프로그래밍대회 기출문제 입니다."
+        :total="100"
+        :complete="80"
+        progress-text="problems"
+        color="#FFC3DA"
+      />
+    </Variant>
   </Story>
 </template>

--- a/frontend/src/common/components/Molecule/ProgressCard.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  title?: string
+  header?: string
+  description?: string
+  type?: string
+  color?: string
+  total?: number
+  complete?: number
+}>()
+const width = (props.complete / props.total) * 100
+
+const shadowColor = computed(() => {
+  return props.type == 'problem'
+    ? 'box-shadow: 0 4px 8px 4px #7a7c7b;'
+    : `box-shadow: 0 4px 8px 4px ${props.color};`
+})
+const progressColor = computed(() => {
+  return props.type == 'problem'
+    ? 'background-color: #7a7c7b;'
+    : `background-color: ${props.color};`
+})
+const progressWidth = computed(() => {
+  return `width: ${width}%;`
+})
+</script>
+
+<template>
+  <div class="m-12 w-1/2 min-w-min rounded-lg p-12" :style="shadowColor">
+    <div class="text-text-title text-xs">{{ header }}</div>
+    <div class="text-text-title mb-2 text-2xl">{{ title }}</div>
+    <div class="mb-4">{{ description }}</div>
+    <!-- progress bar -->
+    <div class="w-full text-right">
+      {{ complete + ' / ' + total }}
+      <span v-if="type == 'problem'">Problems</span>
+      <div class="bg-gray-light relative h-6 w-full rounded-full">
+        <div
+          class="absolute h-6 rounded-full"
+          :style="[progressColor, progressWidth]"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/common/components/Molecule/ProgressCard.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.vue
@@ -1,24 +1,25 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+type progressType = 'score' | 'problem'
 
 const props = defineProps<{
   title?: string
   header?: string
   description?: string
-  type?: string
+  type?: progressType
   color?: string
-  total?: number
-  complete?: number
+  total: number
+  complete: number
 }>()
 const width = (props.complete / props.total) * 100
 
 const shadowColor = computed(() => {
-  return props.type == 'problem'
+  return props.type === 'problem'
     ? 'box-shadow: 0 4px 8px 4px #7a7c7b;'
     : `box-shadow: 0 4px 8px 4px ${props.color};`
 })
 const progressColor = computed(() => {
-  return props.type == 'problem'
+  return props.type === 'problem'
     ? 'background-color: #7a7c7b;'
     : `background-color: ${props.color};`
 })

--- a/frontend/src/common/components/Molecule/ProgressCard.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
 
 const width = computed(() => (props.complete / props.total) * 100)
 
+// TODO: define available color set
 const shadowColor = computed(
   () => `box-shadow: 0 4px 8px 4px ${props.color || '#7a7c7b'};`
 )

--- a/frontend/src/common/components/Molecule/ProgressCard.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.vue
@@ -1,27 +1,26 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-type progressType = 'score' | 'problem'
 
 const props = defineProps<{
   title?: string
   header?: string
   description?: string
-  type?: progressType
   color?: string
   total: number
   complete: number
+  progressText?: string
 }>()
 const width = (props.complete / props.total) * 100
 
 const shadowColor = computed(() => {
-  return props.type === 'problem'
-    ? 'box-shadow: 0 4px 8px 4px #7a7c7b;'
-    : `box-shadow: 0 4px 8px 4px ${props.color};`
+  return props.color
+    ? `box-shadow: 0 4px 8px 4px ${props.color};`
+    : 'box-shadow: 0 4px 8px 4px #7a7c7b;'
 })
 const progressColor = computed(() => {
-  return props.type === 'problem'
-    ? 'background-color: #7a7c7b;'
-    : `background-color: ${props.color};`
+  return props.color
+    ? `background-color: ${props.color};`
+    : 'background-color: #7a7c7b;'
 })
 const progressWidth = computed(() => {
   return `width: ${width}%;`
@@ -36,7 +35,7 @@ const progressWidth = computed(() => {
     <!-- progress bar -->
     <div class="w-full text-right">
       {{ complete + ' / ' + total }}
-      <span v-if="type == 'problem'">Problems</span>
+      <span v-if="progressText">{{ ' ' + progressText }}</span>
       <div class="bg-gray-light relative h-6 w-full rounded-full">
         <div
           class="absolute h-6 rounded-full"

--- a/frontend/src/common/components/Molecule/ProgressCard.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.vue
@@ -28,7 +28,7 @@ const progressWidth = computed(() => {
 </script>
 
 <template>
-  <div class="m-12 w-1/2 min-w-min rounded-lg p-12" :style="shadowColor">
+  <div class="m-4 w-1/2 min-w-min rounded-lg p-12" :style="shadowColor">
     <div class="text-text-title text-xs">{{ header }}</div>
     <div class="text-text-title mb-2 text-2xl">{{ title }}</div>
     <div class="mb-4">{{ description }}</div>

--- a/frontend/src/common/components/Molecule/ProgressCard.vue
+++ b/frontend/src/common/components/Molecule/ProgressCard.vue
@@ -10,20 +10,19 @@ const props = defineProps<{
   complete: number
   progressText?: string
 }>()
-const width = (props.complete / props.total) * 100
 
-const shadowColor = computed(() => {
-  return props.color
-    ? `box-shadow: 0 4px 8px 4px ${props.color};`
-    : 'box-shadow: 0 4px 8px 4px #7a7c7b;'
-})
-const progressColor = computed(() => {
-  return props.color
-    ? `background-color: ${props.color};`
-    : 'background-color: #7a7c7b;'
-})
+const width = computed(() => (props.complete / props.total) * 100)
+
+const shadowColor = computed(
+  () => `box-shadow: 0 4px 8px 4px ${props.color || '#7a7c7b'};`
+)
+
+const progressColor = computed(
+  () => `background-color: ${props.color || '#7a7c7b'};`
+)
+
 const progressWidth = computed(() => {
-  return `width: ${width}%;`
+  return `width: ${width.value}%;`
 })
 </script>
 
@@ -40,7 +39,7 @@ const progressWidth = computed(() => {
         <div
           class="absolute h-6 rounded-full"
           :style="[progressColor, progressWidth]"
-        ></div>
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Description
워크북의 진행 상황을 나타내기 위한 card progress 구현
<img width="383" alt="image" src="https://user-images.githubusercontent.com/75013515/178936755-8fd1fe2b-40ed-4d7f-b8c6-5cfc9c5c3e22.png">
closes #78
closes #75

#### 사용예시
```
<ProgressCard
      title="프로그래밍대회"
      header="updated 3.30"
      description="프로그래밍대회 기출문제 입니다."
      type="problem"
      total="10"
      complete="6"
  />
```

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
