### PR TITLE
feat(be): implement role-based guard

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,8 @@ import { SubmissionModule } from './submission/submission.module'
 import { UserModule } from './user/user.module'
 import { WorkbookModule } from './workbook/workbook.module'
 import { CacheConfigService } from './common/cache/cacheConfig.service'
+import { APP_GUARD } from '@nestjs/core'
+import { JwtAuthGuard } from './auth/guard/jwt-auth.guard'
 
 @Module({
   imports: [
@@ -33,6 +35,6 @@ import { CacheConfigService } from './common/cache/cacheConfig.service'
     WorkbookModule
   ],
   controllers: [AppController],
-  providers: [AppService]
+  providers: [AppService, { provide: APP_GUARD, useClass: JwtAuthGuard }]
 })
 export class AppModule {}

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { UserService } from 'src/user/user.service'
 import { AuthController } from './auth.controller'
 import { AuthService } from './auth.service'
 
@@ -8,7 +9,10 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [{ provide: AuthService, useValue: {} }]
+      providers: [
+        { provide: AuthService, useValue: {} },
+        { provide: UserService, useValue: {} }
+      ]
     }).compile()
     controller = module.get<AuthController>(AuthController)
   })

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,6 +1,5 @@
 import {
   Controller,
-  UseGuards,
   Body,
   Get,
   Post,
@@ -22,9 +21,9 @@ import {
   AUTH_TYPE
 } from './constants/jwt.constants'
 import { LoginUserDto } from './dto/login-user.dto'
-import { JwtAuthGuard } from './guard/jwt-auth.guard'
 import { AuthenticatedRequest } from './interface/authenticated-request.interface'
 import { JwtTokens } from './interface/jwt.interface'
+import { Public } from 'src/common/decorator/public.decorator'
 
 @Controller('auth')
 export class AuthController {
@@ -39,6 +38,7 @@ export class AuthController {
     )
   }
 
+  @Public()
   @Post('login')
   async login(
     @Body() loginUserDto: LoginUserDto,
@@ -56,7 +56,6 @@ export class AuthController {
     }
   }
 
-  @UseGuards(JwtAuthGuard)
   @Post('logout')
   async logout(
     @Req() req: AuthenticatedRequest,

--- a/backend/src/auth/guard/jwt-auth.guard.ts
+++ b/backend/src/auth/guard/jwt-auth.guard.ts
@@ -1,6 +1,7 @@
 import { ExecutionContext, Injectable } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { AuthGuard } from '@nestjs/passport'
+import { Observable } from 'rxjs'
 import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator'
 
 @Injectable()
@@ -9,7 +10,9 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     super()
   }
 
-  canActivate(context: ExecutionContext) {
+  canActivate(
+    context: ExecutionContext
+  ): boolean | Promise<boolean> | Observable<boolean> {
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
       context.getClass()

--- a/backend/src/auth/guard/jwt-auth.guard.ts
+++ b/backend/src/auth/guard/jwt-auth.guard.ts
@@ -2,9 +2,10 @@ import { ExecutionContext, Injectable } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { AuthGuard } from '@nestjs/passport'
 import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator'
+import { CanActivate } from '@nestjs/common'
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {
+export class JwtAuthGuard extends AuthGuard('jwt') implements CanActivate {
   constructor(private reflector: Reflector) {
     super()
   }

--- a/backend/src/auth/guard/jwt-auth.guard.ts
+++ b/backend/src/auth/guard/jwt-auth.guard.ts
@@ -1,5 +1,22 @@
-import { Injectable } from '@nestjs/common'
+import { ExecutionContext, Injectable } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
 import { AuthGuard } from '@nestjs/passport'
+import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator'
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super()
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass()
+    ])
+    if (isPublic) {
+      return true
+    }
+    return super.canActivate(context)
+  }
+}

--- a/backend/src/auth/guard/jwt-auth.guard.ts
+++ b/backend/src/auth/guard/jwt-auth.guard.ts
@@ -2,10 +2,9 @@ import { ExecutionContext, Injectable } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { AuthGuard } from '@nestjs/passport'
 import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator'
-import { CanActivate } from '@nestjs/common'
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') implements CanActivate {
+export class JwtAuthGuard extends AuthGuard('jwt') {
   constructor(private reflector: Reflector) {
     super()
   }

--- a/backend/src/common/decorator/public.decorator.ts
+++ b/backend/src/common/decorator/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common'
+
+export const IS_PUBLIC_KEY = 'public'
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true)

--- a/backend/src/common/decorator/roles.decorator.ts
+++ b/backend/src/common/decorator/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common'
+import { Role } from '@prisma/client'
+
+export const ROLES_KEY = 'role'
+export const Roles = (role: Role) => SetMetadata(ROLES_KEY, role)

--- a/backend/src/user/guard/roles.guard.ts
+++ b/backend/src/user/guard/roles.guard.ts
@@ -12,14 +12,14 @@ import { AuthenticatedRequest } from '../../auth/interface/authenticated-request
 
 @Injectable()
 export class RolesGuard implements CanActivate {
-  rolesHierarchy = {}
+  #rolesHierarchy = {}
 
   constructor(
     private readonly reflector: Reflector,
     private readonly userService: UserService
   ) {
     Object.keys(Role).forEach((key, index) => {
-      this.rolesHierarchy[key] = index
+      this.#rolesHierarchy[key] = index
     })
   }
 
@@ -39,7 +39,7 @@ export class RolesGuard implements CanActivate {
       throw new UnauthorizedException()
     }
 
-    if (this.rolesHierarchy[userRole.role] >= this.rolesHierarchy[role]) {
+    if (this.#rolesHierarchy[userRole.role] >= this.#rolesHierarchy[role]) {
       return true
     }
     return false

--- a/backend/src/user/guard/roles.guard.ts
+++ b/backend/src/user/guard/roles.guard.ts
@@ -1,0 +1,52 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException
+} from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { Role } from '@prisma/client'
+import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator'
+import { ROLES_KEY } from 'src/common/decorator/roles.decorator'
+import { UserService } from 'src/user/user.service'
+import { AuthenticatedRequest } from '../../auth/interface/authenticated-request.interface'
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  rolesHierarchy = {}
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly userService: UserService
+  ) {
+    Object.keys(Role).forEach((key, index) => {
+      this.rolesHierarchy[key] = index
+    })
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass()
+    ])
+    const role = this.reflector.getAllAndOverride<Role>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass()
+    ])
+
+    if (isPublic || !role) {
+      return true
+    }
+
+    const request: AuthenticatedRequest = context.switchToHttp().getRequest()
+    const userRole = await this.userService.getUserRole(request.user.id)
+    if (!userRole) {
+      throw new UnauthorizedException()
+    }
+
+    if (this.rolesHierarchy[userRole.role] >= this.rolesHierarchy[role]) {
+      return true
+    }
+    return false
+  }
+}

--- a/backend/src/user/guard/roles.guard.ts
+++ b/backend/src/user/guard/roles.guard.ts
@@ -6,7 +6,6 @@ import {
 } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { Role } from '@prisma/client'
-import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator'
 import { ROLES_KEY } from 'src/common/decorator/roles.decorator'
 import { UserService } from 'src/user/user.service'
 import { AuthenticatedRequest } from '../../auth/interface/authenticated-request.interface'
@@ -25,16 +24,12 @@ export class RolesGuard implements CanActivate {
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-      context.getHandler(),
-      context.getClass()
-    ])
     const role = this.reflector.getAllAndOverride<Role>(ROLES_KEY, [
       context.getHandler(),
       context.getClass()
     ])
 
-    if (isPublic || !role) {
+    if (!role) {
       return true
     }
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "esnext",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "baseUrl": ".",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,


### PR DESCRIPTION
### Description

`user`의 `role`을 기반으로 API 호출 권한을 확인하는 Guard를 구현합니다.

- `RolesGuard`를 사용하려면 `UserModule`을 import해야 합니다. 
-  `RolesGuard`를 사용하려면 아래 예시 코드처럼 해당 handler 또는 controller class에 `@UseGuards(RolesGuard)`, `@Roles(<Role Type>)`을 추가해야 합니다.
- handler(method)의 `@Roles`가 class의 `@Roles`보다 우선순위가 높습니다. class에 `@Roles(Role.SuperAdmin)`이 적용되어도 handler에 `@Roles(Role.GroupAdmin)`이 적용되었다면 해당 handler는 `GroupAdmin` 이상의 권한을 가진 모든 user가 접근이 가능합니다. 
   - Role은 계층 구조를 가집니다(`User < GroupAdmin < SuperManager < SuperAdmin`)
```typescript
// example code

import { Controller, Get, UseGuards } from '@nestjs/common'
import { Role } from '@prisma/client'
import { Roles } from 'src/common/decorator/roles.decorator'
import { RolesGuard } from 'src/user/guard/roles.guard'
import { ExampleService } from './example.service'

@Controller()
export class ExampleController {

  @Roles(Role.GroupAdmin)
  @UseGuards(RolesGuard)
  @Get()
  async testAPI() {
    return 'RolesGuard'
  }
}
```

Closes #128 

### Additional context

- `JwtAuthGuard`는 global guard로 변경하였습니다. 대부분의 API에서 JWT 인증이 필요하고, `RolesGuard`는 해당 인증이 통과되었다는 것을 전제로 동작하기 때문입니다. 만약 JWT 인증이 필요하지 않은 Public API의 경우 `@Public()` 데코레이터를 사용하면 별도의 인증 절차 없이 `JwtAuthGuard` 및 `RolesGuard`를 통과할 수 있습니다.
- 순환 참조 방지 및 일관된 import 형태를 위해 `RolesGuard`는 `user` 디렉토리에 포함합니다. 
- Role은 `prisma.schema`에는 `enum`으로 설정되어 있으나 `@prisma/client`에서는 literal type으로 사용됩니다.
---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it