### PR TITLE
feat(fe): add popover component

### DIFF
--- a/frontend/src/common/components/Atom/Popover.story.vue
+++ b/frontend/src/common/components/Atom/Popover.story.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import Popover from './Popover.vue'
+import Button from './Button.vue'
+</script>
+
+<template>
+  <Story :layout="{ type: 'grid' }">
+    <Variant title="hover">
+      <Popover
+        text="this is popover : hover"
+        content-id="#pop"
+        hover
+        class="my-12"
+      >
+        <template #content>
+          <div id="pop"></div>
+          <Button>Button</Button>
+        </template>
+      </Popover>
+    </Variant>
+    <Variant title="click">
+      <Popover
+        text="this is popover : click"
+        content-id="#pop-click"
+        class="my-12"
+      >
+        <template #content>
+          <div id="pop-click"></div>
+          <Button>Button</Button>
+        </template>
+      </Popover>
+    </Variant>
+  </Story>
+</template>

--- a/frontend/src/common/components/Atom/Popover.story.vue
+++ b/frontend/src/common/components/Atom/Popover.story.vue
@@ -13,8 +13,7 @@ import Button from './Button.vue'
         class="my-12"
       >
         <template #content>
-          <div id="pop"></div>
-          <Button>Button</Button>
+          <Button id="pop">Button</Button>
         </template>
       </Popover>
     </Variant>
@@ -25,8 +24,7 @@ import Button from './Button.vue'
         class="my-12"
       >
         <template #content>
-          <div id="pop-click"></div>
-          <Button>Button</Button>
+          <Button id="pop-click">Button</Button>
         </template>
       </Popover>
     </Variant>

--- a/frontend/src/common/components/Atom/Popover.vue
+++ b/frontend/src/common/components/Atom/Popover.vue
@@ -31,10 +31,10 @@ const setHoverFalse = () => {
     </span>
     <teleport v-if="mounted && open" :to="contentId">
       <span
-        class="border-t-gray absolute bottom-full ml-2 border-x-8 border-t-8 border-b-0 border-solid border-x-transparent"
+        class="border-t-gray absolute left-0 bottom-full ml-2 border-x-8 border-t-8 border-b-0 border-solid border-x-transparent"
       />
       <span
-        class="bg-gray absolute bottom-full my-2 whitespace-nowrap rounded px-2 py-1"
+        class="bg-gray text-text absolute left-0 bottom-full my-2 whitespace-nowrap rounded px-2 py-1"
       >
         {{ text }}
       </span>

--- a/frontend/src/common/components/Atom/Popover.vue
+++ b/frontend/src/common/components/Atom/Popover.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const props = defineProps<{
+  text: string
+  contentId: string
+  hover?: boolean
+}>()
+
+const mounted = ref(false)
+onMounted(() => {
+  mounted.value = true
+})
+
+const open = ref(false)
+const toggle = () => {
+  if (!props.hover) open.value = !open.value
+}
+const setHover = () => {
+  if (props.hover) open.value = true
+}
+const setHoverFalse = () => {
+  if (props.hover) open.value = false
+}
+</script>
+
+<template>
+  <div class="relative">
+    <span @click="toggle" @mouseover="setHover" @mouseleave="setHoverFalse">
+      <slot name="content" />
+    </span>
+    <teleport v-if="mounted && open" :to="contentId">
+      <span
+        class="border-t-gray absolute bottom-full ml-2 border-x-8 border-t-8 border-b-0 border-solid border-x-transparent"
+      />
+      <span
+        class="bg-gray absolute bottom-full my-2 whitespace-nowrap rounded px-2 py-1"
+      >
+        {{ text }}
+      </span>
+    </teleport>
+  </div>
+</template>


### PR DESCRIPTION
### Description
어떤 요소를 click / hover 했을 때 나타나는 popover 구현
<img width="161" alt="image" src="https://user-images.githubusercontent.com/75013515/180616185-4852959c-ada1-4ab9-bf2a-1041a7b829de.png">
close #125 
close #135 

### 사용법
- `text` prop로 popover에 나타낼 text 내용을 작성하고, `content-id`에 hover/click 대상의 id값을 작성합니다.
- template content에 hover/click 대상을 작성합니다.
- `hover`를 prop으로 주어지면 content 내의 대상을 hover했을 때 popover가 trigger되고, `hover` prop이 주어지지 않으면 click 했을 때 trigger 됩니다.

```
<Popover
    text="this is popover"
    content-id="#pop"
    hover
>
    <template #content>
          <Button id="pop">Button</Button>
    </template>
</Popover>
```

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
