### PR TITLE
fix(be): import usermodule in contest module

### DIFF
--- a/backend/src/contest/contest.module.ts
+++ b/backend/src/contest/contest.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { GroupModule } from 'src/group/group.module'
 import { GroupService } from 'src/group/group.service'
+import { UserModule } from 'src/user/user.module'
 import {
   ContestAdminController,
   GroupContestAdminController
@@ -9,13 +10,13 @@ import { ContestController, GroupContestController } from './contest.controller'
 import { ContestService } from './contest.service'
 
 @Module({
-  imports: [GroupModule],
+  imports: [GroupModule, UserModule],
   controllers: [
     ContestController,
     GroupContestController,
     ContestAdminController,
     GroupContestAdminController
   ],
-  providers: [ContestService, GroupService]
+  providers: [ContestService]
 })
 export class ContestModule {}

--- a/backend/src/contest/contest.module.ts
+++ b/backend/src/contest/contest.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common'
 import { GroupModule } from 'src/group/group.module'
-import { GroupService } from 'src/group/group.service'
 import { UserModule } from 'src/user/user.module'
 import {
   ContestAdminController,

--- a/backend/src/notice/notice.controller.ts
+++ b/backend/src/notice/notice.controller.ts
@@ -9,9 +9,8 @@ import {
   InternalServerErrorException
 } from '@nestjs/common'
 import { NoticeService } from './notice.service'
-import { Notice, Role } from '@prisma/client'
+import { Notice } from '@prisma/client'
 import { Public } from 'src/common/decorator/public.decorator'
-import { Roles } from 'src/common/decorator/roles.decorator'
 import { RolesGuard } from 'src/user/guard/roles.guard'
 import { GroupMemberGuard } from 'src/group/guard/group-member.guard'
 import { UserNotice } from './interface/user-notice.interface'


### PR DESCRIPTION
### Description
Resolves #184 
contest module에 usermodule이 import되지 않아 발생하는 "Can't resolve dependencies" 에러를 해결합니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
