### PR TITLE
feat(fe): add page layout

### DIFF
--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="histoire/vue" />
 /// <reference types="unplugin-icons/types/vue" />
 /// <reference types="vite-plugin-pages/client" />
+/// <reference types="vite-plugin-vue-layouts/client" />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "unplugin-icons": "^0.14.10",
     "vite": "^3.1.2",
     "vite-plugin-pages": "^0.26.0",
+    "vite-plugin-vue-layouts": "^0.7.0",
     "vue-tsc": "^0.40.13"
   }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
 import Toast from '@/common/components/Atom/Toast.vue'
-import Footer from './common/components/Organism/Footer.vue'
-import Header from './common/components/Organism/Header.vue'
 </script>
 
 <template>
-  <Header />
-  <div class="mx-auto w-4/5 max-w-7xl">
+  <div>
     <router-view />
     <Toast />
   </div>
-  <Footer />
 </template>

--- a/frontend/src/common/components/Organism/Sidebar.vue
+++ b/frontend/src/common/components/Organism/Sidebar.vue
@@ -7,7 +7,7 @@ import IconBrain from '~icons/fluent/brain-circuit-24-regular'
 import IconBox from '~icons/bi/box'
 import IconCode from '~icons/bi/code-square'
 import IconBook from '~icons/bi/journals'
-import { onBeforeMount } from 'vue'
+import { computed } from 'vue'
 import CodingPlatformLogo from '../Atom/CodingPlatformLogo.vue'
 
 // TODO: get group name and color
@@ -23,7 +23,7 @@ const colorMapper = {
   default: 'border-l-green'
 }
 
-let items = [
+const commonItems = [
   { to: '/notice', name: 'Notice', icon: IconFile },
   { to: '/contest', name: 'Contest', icon: IconTrophy },
   { to: '/workbook', name: 'Workbook', icon: IconBook },
@@ -31,15 +31,16 @@ let items = [
   { to: '/pool', name: 'Problem Pool', icon: IconBox }
 ]
 
-onBeforeMount(() => {
-  if (props.group) {
-    items.unshift({ to: '/', name: 'SKKUDING', icon: IconBiHouse })
-    items.push(
-      { to: '/member', name: 'Member', icon: IconUser },
-      { to: '/submission', name: 'Submission', icon: IconCode }
-    )
-  }
-})
+const items = computed(() =>
+  props.group
+    ? [
+        { to: '/', name: 'SKKUDING', icon: IconBiHouse },
+        ...commonItems,
+        { to: '/member', name: 'Member', icon: IconUser },
+        { to: '/submission', name: 'Submission', icon: IconCode }
+      ]
+    : commonItems
+)
 </script>
 
 <template>

--- a/frontend/src/common/layouts/admin.vue
+++ b/frontend/src/common/layouts/admin.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import Sidebar from '../components/Organism/Sidebar.vue'
+
+const group = ref(false)
 </script>
 
 <template>
   <div class="flex w-fit">
-    <Sidebar />
-    <router-view />
+    <Sidebar :group="group" />
+    <router-view @toggle-group="(value: boolean) => (group = value)" />
   </div>
 </template>

--- a/frontend/src/common/layouts/admin.vue
+++ b/frontend/src/common/layouts/admin.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import Sidebar from '../components/Organism/Sidebar.vue'
+</script>
+
+<template>
+  <div class="flex w-fit">
+    <Sidebar />
+    <router-view />
+  </div>
+</template>

--- a/frontend/src/common/layouts/admin.vue
+++ b/frontend/src/common/layouts/admin.vue
@@ -6,8 +6,10 @@ const group = ref(false)
 </script>
 
 <template>
-  <div class="flex w-fit">
-    <Sidebar :group="group" />
-    <router-view @toggle-group="(value: boolean) => (group = value)" />
+  <div class="flex w-full">
+    <Sidebar :group="group" class="flex-none" />
+    <main class="h-screen flex-1 overflow-auto">
+      <router-view @toggle-group="(value: boolean) => (group = value)" />
+    </main>
   </div>
 </template>

--- a/frontend/src/common/layouts/default.vue
+++ b/frontend/src/common/layouts/default.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import Header from '../components/Organism/Header.vue'
+import Footer from '../components/Organism/Footer.vue'
+</script>
+
+<template>
+  <Header />
+  <router-view class="mx-auto w-4/5 max-w-7xl" />
+  <Footer />
+</template>

--- a/frontend/src/common/layouts/default.vue
+++ b/frontend/src/common/layouts/default.vue
@@ -6,6 +6,10 @@ import { defineAsyncComponent } from 'vue'
 const Carousel = defineAsyncComponent(
   () => import('@/user/home/components/Carousel.vue')
 )
+
+const BoxTitle = defineAsyncComponent(
+  () => import('@/common/components/Atom/BoxTitle.vue')
+)
 </script>
 
 <template>
@@ -20,6 +24,12 @@ const Carousel = defineAsyncComponent(
       'https://picsum.photos/id/1036/900/400'
     ]"
   />
+  <BoxTitle v-if="$router.currentRoute.value.meta.title">
+    <template #title>{{ $router.currentRoute.value.meta.title }}</template>
+    <template #subtitle>
+      {{ $router.currentRoute.value.meta.subtitle }}
+    </template>
+  </BoxTitle>
   <main class="mx-auto w-4/5 max-w-7xl">
     <router-view />
   </main>

--- a/frontend/src/common/layouts/default.vue
+++ b/frontend/src/common/layouts/default.vue
@@ -1,10 +1,25 @@
 <script setup lang="ts">
 import Header from '../components/Organism/Header.vue'
 import Footer from '../components/Organism/Footer.vue'
+import { defineAsyncComponent } from 'vue'
+
+const Carousel = defineAsyncComponent(
+  () => import('@/user/home/components/Carousel.vue')
+)
 </script>
 
 <template>
   <Header />
+  <Carousel
+    v-if="$router.currentRoute.value.meta.home"
+    :slides="[
+      'https://picsum.photos/id/1032/900/400',
+      'https://picsum.photos/id/1033/900/400',
+      'https://picsum.photos/id/1037/900/400',
+      'https://picsum.photos/id/1035/900/400',
+      'https://picsum.photos/id/1036/900/400'
+    ]"
+  />
   <router-view class="mx-auto w-4/5 max-w-7xl" />
   <Footer />
 </template>

--- a/frontend/src/common/layouts/default.vue
+++ b/frontend/src/common/layouts/default.vue
@@ -20,6 +20,8 @@ const Carousel = defineAsyncComponent(
       'https://picsum.photos/id/1036/900/400'
     ]"
   />
-  <router-view class="mx-auto w-4/5 max-w-7xl" />
+  <main class="mx-auto w-4/5 max-w-7xl">
+    <router-view />
+  </main>
   <Footer />
 </template>

--- a/frontend/src/common/layouts/empty.vue
+++ b/frontend/src/common/layouts/empty.vue
@@ -1,0 +1,1 @@
+<template><router-view /></template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,7 +4,8 @@ import { createPinia } from 'pinia'
 import { useAuthStore } from '@/common/store/auth'
 import axios, { AxiosError } from 'axios'
 import NProgress from 'nprogress'
-import routes from 'virtual:generated-pages'
+import { setupLayouts } from 'virtual:generated-layouts'
+import generatedRoutes from 'virtual:generated-pages'
 import App from './App.vue'
 
 import 'nprogress/nprogress.css'
@@ -34,7 +35,7 @@ axios.interceptors.response.use(undefined, async (error: AxiosError) => {
 const app = createApp(App)
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes
+  routes: setupLayouts(generatedRoutes)
 })
 
 router.beforeEach(() => {

--- a/frontend/src/user/home/components/Carousel.vue
+++ b/frontend/src/user/home/components/Carousel.vue
@@ -22,7 +22,7 @@ const { pause, resume } = useIntervalFn(() => {
 
 <template>
   <div
-    class="bg-gray/50 relative h-80 w-full overflow-hidden md:h-96 lg:h-[36rem]"
+    class="bg-gray/50 relative h-80 w-full overflow-hidden md:h-96 lg:h-[30rem]"
   >
     <div class="absolute left-1/2 bottom-5 z-10 flex -translate-x-1/2 gap-2">
       <button

--- a/frontend/src/user/home/pages/index.vue
+++ b/frontend/src/user/home/pages/index.vue
@@ -42,33 +42,31 @@ const contestItems = [
 </script>
 
 <template>
-  <main>
-    <div
-      class="my-20 flex flex-col items-center justify-center gap-12 lg:flex-row lg:items-start"
-    >
-      <Card href="/notice" :items="noticeItems" class="w-[36rem] max-w-full">
-        <template #title>
-          <IconInfo />
-          <h2 class="ml-2">Notice</h2>
-        </template>
+  <div
+    class="my-20 flex flex-col items-center justify-center gap-12 lg:flex-row lg:items-start"
+  >
+    <Card href="/notice" :items="noticeItems" class="w-[36rem] max-w-full">
+      <template #title>
+        <IconInfo />
+        <h2 class="ml-2">Notice</h2>
+      </template>
 
-        <template #icon>
-          <IconAngleRight />
-        </template>
-      </Card>
-      <Card href="/contest" :items="contestItems" class="w-[36rem] max-w-full">
-        <template #title>
-          <IconMedal />
-          <h2 class="ml-2">Current/Upcoming Contests</h2>
-        </template>
+      <template #icon>
+        <IconAngleRight />
+      </template>
+    </Card>
+    <Card href="/contest" :items="contestItems" class="w-[36rem] max-w-full">
+      <template #title>
+        <IconMedal />
+        <h2 class="ml-2">Current/Upcoming Contests</h2>
+      </template>
 
-        <template #icon="item">
-          <IconEllipsis v-if="item.item === 'ongoing'" />
-          <IconCalendar v-else />
-        </template>
-      </Card>
-    </div>
-  </main>
+      <template #icon="item">
+        <IconEllipsis v-if="item.item === 'ongoing'" />
+        <IconCalendar v-else />
+      </template>
+    </Card>
+  </div>
 </template>
 
 <route lang="yaml">

--- a/frontend/src/user/home/pages/index.vue
+++ b/frontend/src/user/home/pages/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import Card from '../components/Card.vue'
-import Carousel from '../components/Carousel.vue'
 import IconInfo from '~icons/fa6-solid/circle-info'
 import IconAngleRight from '~icons/fa6-solid/angle-right'
 import IconMedal from '~icons/fa6-solid/medal'
@@ -40,19 +39,10 @@ const contestItems = [
     state: 'prearranged'
   }
 ]
-
-const slides = [
-  'https://picsum.photos/id/1032/900/400',
-  'https://picsum.photos/id/1033/900/400',
-  'https://picsum.photos/id/1037/900/400',
-  'https://picsum.photos/id/1035/900/400',
-  'https://picsum.photos/id/1036/900/400'
-]
 </script>
 
 <template>
   <main>
-    <Carousel :slides="slides" />
     <div
       class="my-20 flex flex-col items-center justify-center gap-12 lg:flex-row lg:items-start"
     >
@@ -80,3 +70,8 @@ const slides = [
     </div>
   </main>
 </template>
+
+<route lang="yaml">
+meta:
+  home: true
+</route>

--- a/frontend/src/user/problem/pages/index.vue
+++ b/frontend/src/user/problem/pages/index.vue
@@ -3,7 +3,6 @@ import PageSubtitle from '@/common/components/Atom/PageSubtitle.vue'
 import PaginationTable from '@/common/components/Organism/PaginationTable.vue'
 import SearchBar from '@/common/components/Molecule/SearchBar.vue'
 import ProgressCard from '@/common/components/Molecule/ProgressCard.vue'
-import BoxTitle from '@/common/components/Atom/BoxTitle.vue'
 import Switch from '@/common/components/Molecule/Switch.vue'
 import Button from '@/common/components/Atom/Button.vue'
 import { ref, computed } from 'vue'
@@ -224,12 +223,6 @@ const clickMore = () => {
 </script>
 
 <template>
-  <BoxTitle>
-    <template #title>Problem</template>
-    <template #subtitle>
-      Find problems with problem set and filters, and solve it!
-    </template>
-  </BoxTitle>
   <PageSubtitle text="All Problem" class="mt-10 mb-2" />
   <PaginationTable
     :fields="fields"
@@ -276,3 +269,9 @@ const clickMore = () => {
     More
   </Button>
 </template>
+
+<route lang="yaml">
+meta:
+  title: Problem
+  subtitle: Find problems with problem set and filters, and solve it!
+</route>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import icons from 'unplugin-icons/vite'
 import pages from 'vite-plugin-pages'
+import layouts from 'vite-plugin-vue-layouts'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -20,6 +21,9 @@ export default defineConfig({
         { dir: 'src/user/workbook/pages', baseRoute: 'workbook' },
         { dir: 'src/manager/pages', baseRoute: 'manager' }
       ]
+    }),
+    layouts({
+      layoutsDirs: 'src/common/layouts'
     })
   ],
   resolve: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,7 @@ importers:
       unplugin-icons: ^0.14.10
       vite: ^3.1.2
       vite-plugin-pages: ^0.26.0
+      vite-plugin-vue-layouts: ^0.7.0
       vue: ^3.2.39
       vue-router: ^4.1.5
       vue-tsc: ^0.40.13
@@ -190,6 +191,7 @@ importers:
       unplugin-icons: 0.14.10_vite@3.1.2
       vite: 3.1.2
       vite-plugin-pages: 0.26.0_vite@3.1.2
+      vite-plugin-vue-layouts: 0.7.0_qafglid6haducukcg2rjdtbw74
       vue-tsc: 0.40.13_typescript@4.8.3
 
 packages:
@@ -2223,7 +2225,6 @@ packages:
 
   /@vue/devtools-api/6.2.1:
     resolution: {integrity: sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ==}
-    dev: false
 
   /@vue/reactivity-transform/3.2.39:
     resolution: {integrity: sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==}
@@ -8855,6 +8856,23 @@ packages:
       - supports-color
     dev: true
 
+  /vite-plugin-vue-layouts/0.7.0_qafglid6haducukcg2rjdtbw74:
+    resolution: {integrity: sha512-k5XDmRNFo4M/GmUjhbRXj2WmJiFcGoVI8l/uZ72RHyRDQr4wE/6Zq/KFq0lqXomWQxTSzakQRUswzNwtvZLE8A==}
+    peerDependencies:
+      vite: ^2.5.0 || ^3.0.0-0
+      vue: ^2.6.12 || ^3.2.4
+      vue-router: ^3.5.1 || ^ 4.0.11
+    dependencies:
+      '@vue/compiler-sfc': 3.2.39
+      debug: 4.3.4
+      fast-glob: 3.2.11
+      vite: 3.1.2
+      vue: 3.2.39
+      vue-router: 4.1.5_vue@3.2.39
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /vite/3.1.2:
     resolution: {integrity: sha512-wTDKPkiVbeT+drTPdkuvjVIC/2vKKUc1w3qNOuwgpyvPCZF6fvdxB5v5WEcCsqaYea0zrwA4+XialJKCHM3oVQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -8944,7 +8962,6 @@ packages:
     dependencies:
       '@vue/devtools-api': 6.2.1
       vue: 3.2.39
-    dev: false
 
   /vue-tsc/0.40.13_typescript@4.8.3:
     resolution: {integrity: sha512-xzuN3g5PnKfJcNrLv4+mAjteMd5wLm5fRhW0034OfNJZY4WhB07vhngea/XeGn7wNYt16r7syonzvW/54dcNiA==}


### PR DESCRIPTION
### Description

Closes #212 

vite-plugin-vue-layouts plugin을 이용해서 layout을 만듭니다.
https://github.com/JohnCampionJr/vite-plugin-vue-layouts

### 사용 예시

`common/layouts` folder 안에 layout 파일을 만들고, 페이지 파일에서 원하는 layout을 지정합니다.
따로 layout을 지정하지 않으면 default.vue가 layout으로 적용됩니다.

```vue
<!-- pages/**.vue -->

<template>
...
</template>

<route lang="yaml">
meta:
  layout: empty
</route>
```

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
