### PR TITLE
fix: use the latest volar plugin in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,7 +17,7 @@ vscode:
     - dbaeumer.vscode-eslint
     - editorconfig.editorconfig
     - esbenp.prettier-vscode
-    - johnsoncodehk.volar
+    - lukashass.volar # workaround: official one is not published yet
     - johnsoncodehk.vscode-typescript-vue-plugin
     - Orta.vscode-jest
     - prisma.prisma


### PR DESCRIPTION
### Description

GitPod의 Volar plugin(Vue Language Server)이 최신 버전이 공식적으로 올라오지 않아 language service가 충돌되는 문제가 있습니다.
비공식적으로 올라온 Volar plugin을 임시로 사용하고, 추후 문제가 해결되면 다시 공식 버전을 사용합니다.

공식 버전(0.30.1): https://open-vsx.org/extension/johnsoncodehk/volar
비공식 버전(0.40.6): https://open-vsx.org/extension/lukashass/volar

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
