### PR TITLE
fix: use official vue extension for gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,7 +17,7 @@ vscode:
     - dbaeumer.vscode-eslint
     - editorconfig.editorconfig
     - esbenp.prettier-vscode
-    - lukashass.volar # workaround: official one is not published yet
+    - Vue.volar
     - johnsoncodehk.vscode-typescript-vue-plugin
     - Orta.vscode-jest
     - prisma.prisma


### PR DESCRIPTION
### Description

GitPod에서 Vue extension(Voalr)이 제대로 동작하지 않는 문제를 해결합니다.
기존에 workaround로 사용한 비공식 버전(0.x.x) 대신, 최근 release된 정식 버전(1.x.x)을 사용합니다.

More info: #255 

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/19747913/200746867-5b822dd4-780c-4039-bc47-ea3f0758b00e.png">

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
