### PR TITLE
fix(be): edit foreign field name to camel case

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,17 +28,17 @@ model User {
   createTime            DateTime @default(now()) @map("create_time")
   updateTime            DateTime @updatedAt @map("update_time")
 
-  UserProfile               UserProfile?
-  UserGroup                 UserGroup[]
-  Group                     Group[]
-  Notice                    Notice[]
-  Problem                   Problem[]
-  Contest                   Contest[]
-  ContestRecord             ContestRecord[]
-  ContestRankACM            ContestRankACM[]
-  Workbook                  Workbook[]
-  Submission                Submission[]
-  ContestPublicizingRequest ContestPublicizingRequest[]
+  userProfile               UserProfile?
+  userGroup                 UserGroup[]
+  group                     Group[]
+  notice                    Notice[]
+  problem                   Problem[]
+  contest                   Contest[]
+  contestRecord             ContestRecord[]
+  contestRankACM            ContestRankACM[]
+  workbook                  Workbook[]
+  submission                Submission[]
+  contestPublicizingRequest ContestPublicizingRequest[]
 
   @@map("user")
 }
@@ -81,11 +81,11 @@ model Group {
   createTime     DateTime @default(now()) @map("create_time")
   updateTime     DateTime @updatedAt @map("update_time")
 
-  UserGroup UserGroup[]
-  Notice    Notice[]
-  Problem   Problem[]
-  Contest   Contest[]
-  Workbook  Workbook[]
+  userGroup UserGroup[]
+  notice    Notice[]
+  problem   Problem[]
+  contest   Contest[]
+  workbook  Workbook[]
 
   @@map("group")
 }
@@ -129,11 +129,11 @@ model Problem {
   createTime        DateTime @default(now()) @map("create_time")
   updateTime        DateTime @updatedAt @map("update_time")
 
-  ProblemTestcase ProblemTestcase[]
-  ProblemTag      ProblemTag[]
-  ContestProblem  ContestProblem[]
-  WorkbookProblem WorkbookProblem[]
-  Submission      Submission[]
+  problemTestcase ProblemTestcase[]
+  problemTag      ProblemTag[]
+  contestProblem  ContestProblem[]
+  workbookProblem WorkbookProblem[]
+  submission      Submission[]
 
   @@map("problem")
 }
@@ -169,7 +169,7 @@ model Tag {
   createTime DateTime @default(now()) @map("create_time")
   updateTime DateTime @updatedAt @map("update_time")
 
-  ProblemTag ProblemTag[]
+  problemTag ProblemTag[]
 
   @@map("tag")
 }
@@ -192,12 +192,12 @@ model Contest {
   createTime         DateTime    @default(now()) @map("create_time")
   updateTime         DateTime    @updatedAt @map("update_time")
 
-  ContestNotice             ContestNotice[]
-  ContestProblem            ContestProblem[]
-  ContestRecord             ContestRecord[]
-  ContestRankACM            ContestRankACM[]
-  Submission                Submission[]
-  ContestPublicizingRequest ContestPublicizingRequest[]
+  contestNotice             ContestNotice[]
+  contestProblem            ContestProblem[]
+  contestRecord             ContestRecord[]
+  contestRankACM            ContestRankACM[]
+  submission                Submission[]
+  contestPublicizingRequest ContestPublicizingRequest[]
 
   @@map("contest")
 }
@@ -296,8 +296,8 @@ model Workbook {
   createTime  DateTime @default(now()) @map("create_time")
   updateTime  DateTime @updatedAt @map("update_time")
 
-  WorkbookProblem WorkbookProblem[]
-  Submission      Submission[]
+  workbookProblem WorkbookProblem[]
+  submission      Submission[]
 
   @@map("workbook")
 }
@@ -332,7 +332,7 @@ model Submission {
   createTime DateTime  @default(now()) @map("create_time")
   updateTime DateTime  @updatedAt @map("update_time")
 
-  SubmissionResult SubmissionResult[]
+  submissionResult SubmissionResult[]
 
   @@map("submission")
 }


### PR DESCRIPTION
### Description

@typescript-eslint/naming-convention rule에 따라 object key가 camelCase를 따르도록 설정되어있습니다.
불가피한 경우 `// eslint-disable` 주석으로 비활성화하고 있지만, Prisma Schema에서 다른 model을 참조하는 field name들은 PascalCase에서 camelCase로 수정해도 무관한 것 같습니다.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
