### PR TITLE
feat(be): expel manager from admin page

### DIFF
--- a/backend/src/contest/contest-admin.controller.ts
+++ b/backend/src/contest/contest-admin.controller.ts
@@ -32,22 +32,18 @@ import { RespondContestPublicizingRequestDto } from './dto/respond-publicizing-r
 
 @Controller('admin/contest')
 @UseGuards(RolesGuard)
-@Roles(Role.Manager)
+@Roles(Role.Admin)
 export class ContestAdminController {
   constructor(private readonly contestService: ContestService) {}
 
   @Get()
-  async getAdminContests(
-    @Req() req: AuthenticatedRequest
-  ): Promise<Partial<Contest>[]> {
-    return await this.contestService.getAdminContests(req.user.id)
+  async getAdminContests(): Promise<Partial<Contest>[]> {
+    return await this.contestService.getAdminContests()
   }
 
   @Get('ongoing')
-  async getAdminOngoingContests(
-    @Req() req: AuthenticatedRequest
-  ): Promise<Partial<Contest>[]> {
-    return await this.contestService.getAdminOngoingContests(req.user.id)
+  async getAdminOngoingContests(): Promise<Partial<Contest>[]> {
+    return await this.contestService.getAdminOngoingContests()
   }
 }
 

--- a/backend/src/contest/contest.service.spec.ts
+++ b/backend/src/contest/contest.service.spec.ts
@@ -476,22 +476,20 @@ describe('ContestService', () => {
   })
 
   describe('getAdminContests', () => {
-    it('should return contests in groups whose user is group manager', async () => {
+    it('should return contests in open space', async () => {
       stub(groupService, 'getUserGroupLeaderList').resolves([groupId])
 
-      expect(await contestService.getAdminContests(userId)).to.deep.equal(
-        contests
-      )
+      expect(await contestService.getAdminContests()).to.deep.equal(contests)
     })
   })
 
   describe('getAdminOngoingContests', () => {
-    it('should return ongoing contests in groups whose user is group manager', async () => {
+    it('should return ongoing contests in open space', async () => {
       stub(groupService, 'getUserGroupLeaderList').resolves([groupId])
 
-      expect(
-        await contestService.getAdminOngoingContests(userId)
-      ).to.deep.equal(ongoingContests)
+      expect(await contestService.getAdminOngoingContests()).to.deep.equal(
+        ongoingContests
+      )
     })
   })
 

--- a/backend/src/contest/contest.service.ts
+++ b/backend/src/contest/contest.service.ts
@@ -204,16 +204,15 @@ export class ContestService {
     })
   }
 
-  async getAdminOngoingContests(userId: number): Promise<Partial<Contest>[]> {
-    const contests = await this.getAdminContests(userId)
+  async getAdminOngoingContests(): Promise<Partial<Contest>[]> {
+    const contests = await this.getAdminContests()
     return this.filterOngoing(contests)
   }
 
-  async getAdminContests(userId: number): Promise<Partial<Contest>[]> {
-    const groupIds = await this.groupService.getUserGroupLeaderList(userId)
+  async getAdminContests(): Promise<Partial<Contest>[]> {
     return await this.prisma.contest.findMany({
       where: {
-        groupId: { in: groupIds }
+        groupId: 1
       },
       select: { ...this.contestSelectOption, visible: true }
     })

--- a/backend/src/notice/notice-admin.controller.ts
+++ b/backend/src/notice/notice-admin.controller.ts
@@ -25,16 +25,15 @@ import { RolesGuard } from 'src/user/guard/roles.guard'
 
 @Controller('admin/notice')
 @UseGuards(RolesGuard)
-@Roles(Role.Manager)
+@Roles(Role.Admin)
 export class NoticeAdminController {
   constructor(private readonly noticeService: NoticeService) {}
 
   @Get()
   async getAdminNotices(
-    @Req() req: AuthenticatedRequest,
     @Query('offset', ParseIntPipe) offset: number
   ): Promise<Partial<Notice>[]> {
-    return await this.noticeService.getAdminNotices(req.user.id, offset)
+    return await this.noticeService.getAdminNotices(offset)
   }
 }
 

--- a/backend/src/notice/notice.service.spec.ts
+++ b/backend/src/notice/notice.service.spec.ts
@@ -218,7 +218,10 @@ describe('NoticeService', () => {
     it('should return notice list of the group', async () => {
       db.notice.findMany.resolves(noticeArray)
 
-      const getNoticesByGroupId = await service.getAdminNotices(groupId, 1)
+      const getNoticesByGroupId = await service.getAdminNoticesByGroupId(
+        groupId,
+        1
+      )
       expect(getNoticesByGroupId).to.deep.equal(noticeArray)
     })
   })
@@ -288,16 +291,11 @@ describe('NoticeService', () => {
       }
     ]
 
-    it('should return notice list of the group', async () => {
-      const getUserGroupLeaderListSpy = stub(
-        groupService,
-        'getUserGroupLeaderList'
-      )
+    it('should return notice list in open space', async () => {
       db.notice.findMany.resolves(noticeArray)
 
-      const getNoticesByGroupId = await service.getAdminNotices(userId, 1)
-      expect(getUserGroupLeaderListSpy.calledWith(userId)).to.be.true
-      expect(getNoticesByGroupId).to.deep.equal(noticeArray)
+      const getNotices = await service.getAdminNotices(1)
+      expect(getNotices).to.deep.equal(noticeArray)
     })
   })
 

--- a/backend/src/notice/notice.service.ts
+++ b/backend/src/notice/notice.service.ts
@@ -108,17 +108,10 @@ export class NoticeService {
     }
   }
 
-  async getAdminNotices(
-    userId: number,
-    offset: number
-  ): Promise<Partial<Notice>[]> {
-    const groupIds = await this.group.getUserGroupLeaderList(userId)
-
+  async getAdminNotices(offset: number): Promise<Partial<Notice>[]> {
     return await this.prisma.notice.findMany({
       where: {
-        groupId: {
-          in: groupIds
-        }
+        groupId: 1
       },
       select: {
         id: true,


### PR DESCRIPTION
> Closes #345 

### Description
- User, Manager는 Admin 페이지에 접근할 수 없습니다.
- 페이지에서 보여지는 모든 레코드는 Open Space의 레코드입니다.
- 특정 그룹을 관리하기 위해서는 My Groups 페이지를 방문하여 관리 페이지를 열어야 합니다.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
