### PR TITLE
feat(fe): connect notice list page api

### DIFF
--- a/frontend/src/user/notice/composables/notice.ts
+++ b/frontend/src/user/notice/composables/notice.ts
@@ -24,19 +24,13 @@ export interface Item {
 export const useNotice = () => {
   const notices = ref<Item[]>([])
   async function getNoticeList(currentPage: number) {
-    await axios
-      .get('/api/notice', {
-        params: { offset: (currentPage - 1) * 10 + 1 }
-      })
-      .then((res) => {
-        notices.value = res.data
-        notices.value.map((notice) => {
-          notice.createTime = useDateFormat(
-            notice.createTime,
-            'YYYY-MM-DD'
-          ).value
-        })
-      })
+    const res = await axios.get('/api/notice', {
+      params: { offset: (currentPage - 1) * 10 + 1 }
+    })
+    notices.value = res.data
+    notices.value.map((notice) => {
+      notice.createTime = useDateFormat(notice.createTime, 'YYYY-MM-DD').value
+    })
   }
   // TODO: number of pages api로 받아오기
   const numberOfPages = 2

--- a/frontend/src/user/notice/composables/notice.ts
+++ b/frontend/src/user/notice/composables/notice.ts
@@ -2,6 +2,9 @@ import { useRouter } from 'vue-router'
 import { ref, markRaw, type Component } from 'vue'
 import IconAngleUp from '~icons/fa6-solid/angle-up'
 import IconAngleDown from '~icons/fa6-solid/angle-down'
+import axios from 'axios'
+import { findColumn } from '@codemirror/state'
+import { useDateFormat, useNow } from '@vueuse/core'
 
 export interface Field {
   key: string
@@ -14,60 +17,30 @@ export interface Item {
   name?: 'prev' | 'next'
   id: number
   title: string
-  date?: string
+  createTime?: string
   update?: string
   content?: string
 }
 
 export const useNotice = () => {
-  const notices: Item[] = [
-    {
-      id: 1,
-      title: '111111',
-      date: '2022-05-06'
-    },
-    {
-      id: 2,
-      title: '222222',
-      date: '2022-05-07'
-    },
-    {
-      id: 3,
-      title: '333333',
-      date: '2022-05-07'
-    },
-    {
-      id: 4,
-      title: '444444',
-      date: '2022-05-07'
-    },
-    {
-      id: 5,
-      title: '555555',
-      date: '2022-05-07'
-    },
-    {
-      id: 6,
-      title: '666666',
-      date: '2022-05-07'
-    },
-    {
-      id: 7,
-      title: '777777',
-      date: '2022-05-07'
-    },
-    {
-      id: 8,
-      title: '888888',
-      date: '2022-05-07'
-    },
-    {
-      id: 9,
-      title: '999999',
-      date: '2022-05-07'
-    }
-  ]
-
+  const notices = ref<Item[]>([])
+  async function getNoticeList(currentPage: number) {
+    await axios
+      .get('/api/notice', {
+        params: { offset: (currentPage - 1) * 10 + 1 }
+      })
+      .then((res) => {
+        notices.value = res.data
+        notices.value.map((notice) => {
+          notice.createTime = useDateFormat(
+            notice.createTime,
+            'YYYY-MM-DD'
+          ).value
+        })
+      })
+  }
+  // TODO: number of pages api로 받아오기
+  const numberOfPages = 2
   const currentNotice = ref<Item>()
   const adjacentNotices = ref<Item[]>([])
 
@@ -79,11 +52,11 @@ export const useNotice = () => {
       params: { id }
     })
   }
-
+  // TODO: api 연결
   function getNotice(id: number) {
-    currentNotice.value = notices.find((x) => x.id === id)
-    const previousNotice = notices.find((x) => x.id === id - 1)
-    const nextNotice = notices.find((x) => x.id === id + 1)
+    currentNotice.value = notices.value.find((x) => x.id === id)
+    const previousNotice = notices.value.find((x) => x.id === id - 1)
+    const nextNotice = notices.value.find((x) => x.id === id + 1)
     if (previousNotice) {
       previousNotice.icon = IconAngleUp
       previousNotice.name = 'prev'
@@ -98,8 +71,10 @@ export const useNotice = () => {
 
   return {
     notices,
+    numberOfPages,
     currentNotice,
     adjacentNotices,
+    getNoticeList,
     goDetail,
     getNotice
   }

--- a/frontend/src/user/notice/composables/notice.ts
+++ b/frontend/src/user/notice/composables/notice.ts
@@ -3,8 +3,7 @@ import { ref, markRaw, type Component } from 'vue'
 import IconAngleUp from '~icons/fa6-solid/angle-up'
 import IconAngleDown from '~icons/fa6-solid/angle-down'
 import axios from 'axios'
-import { findColumn } from '@codemirror/state'
-import { useDateFormat, useNow } from '@vueuse/core'
+import { useDateFormat } from '@vueuse/core'
 
 export interface Field {
   key: string

--- a/frontend/src/user/notice/pages/[id].vue
+++ b/frontend/src/user/notice/pages/[id].vue
@@ -12,7 +12,8 @@ const props = defineProps<{
 
 const router = useRouter()
 
-const { currentNotice, adjacentNotices, getNotice, goDetail } = useNotice()
+const { currentNotice, adjacentNotices, numberOfPages, getNotice, goDetail } =
+  useNotice()
 
 onMounted(() => {
   getNotice(parseInt(props.id))
@@ -46,7 +47,7 @@ const field: Field[] = [
         class="!text-text-title"
       />
       <div class="hidden sm:block">
-        {{ currentNotice?.date }}
+        {{ currentNotice?.createTime }}
       </div>
     </div>
     <div class="m-4 text-right text-sm">
@@ -59,7 +60,7 @@ const field: Field[] = [
       no-header
       no-pagination
       no-search-bar
-      :number-of-pages="1"
+      :number-of-pages="numberOfPages"
       :fields="field"
       :items="adjacentNotices"
       @row-clicked="goDetail"

--- a/frontend/src/user/notice/pages/index.vue
+++ b/frontend/src/user/notice/pages/index.vue
@@ -3,9 +3,13 @@ import PaginationTable from '@/common/components/Organism/PaginationTable.vue'
 import PageTitle from '@/common/components/Atom/PageTitle.vue'
 import { useNotice, type Field } from '../composables/notice'
 
-const field: Field[] = [{ key: 'title', width: '70%' }, { key: 'date' }]
-const { notices, goDetail } = useNotice()
+const field: Field[] = [
+  { key: 'title', width: '70%' },
+  { key: 'createTime', label: 'Date' }
+]
+const { notices, numberOfPages, getNoticeList, goDetail } = useNotice()
 
+getNoticeList(1)
 // TODO: 페이지네이션, 검색 기능 추가
 </script>
 
@@ -16,8 +20,9 @@ const { notices, goDetail } = useNotice()
       :fields="field"
       :items="notices"
       text="No Notice"
-      :number-of-pages="1"
+      :number-of-pages="numberOfPages"
       @row-clicked="goDetail"
+      @change-page="getNoticeList"
     />
   </div>
 </template>


### PR DESCRIPTION
### Description

notice list 페이지의 api를 연결했다.
close #320 
### Additional context

pagination 숫자가 바뀌면 다음 10개의 notice list를 가져오도록 했다.
추후에 numberOfPages를 api에서 가져오면 수정할 예정이다.

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [ ] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
