### PR TITLE
refactor: change decorator name 'Public' to 'AuthNotNeeded'

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -23,7 +23,7 @@ import {
 import { LoginUserDto } from './dto/login-user.dto'
 import { AuthenticatedRequest } from './interface/authenticated-request.interface'
 import { JwtTokens } from './interface/jwt.interface'
-import { Public } from 'src/common/decorator/public.decorator'
+import { AuthNotNeeded } from 'src/common/decorator/auth-ignore.decorator'
 
 @Controller('auth')
 export class AuthController {
@@ -38,7 +38,7 @@ export class AuthController {
     )
   }
 
-  @Public()
+  @AuthNotNeeded()
   @Post('login')
   async login(
     @Body() loginUserDto: LoginUserDto,
@@ -70,7 +70,7 @@ export class AuthController {
     }
   }
 
-  @Public()
+  @AuthNotNeeded()
   @Get('reissue')
   async reIssueJwtTokens(
     @Req() req: Request,

--- a/backend/src/auth/guard/jwt-auth.guard.ts
+++ b/backend/src/auth/guard/jwt-auth.guard.ts
@@ -2,7 +2,7 @@ import { ExecutionContext, Injectable } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { AuthGuard } from '@nestjs/passport'
 import { Observable } from 'rxjs'
-import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator'
+import { IS_AUTH_NEEDED_KEY } from 'src/common/decorator/auth-ignore.decorator'
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -13,11 +13,11 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   canActivate(
     context: ExecutionContext
   ): boolean | Promise<boolean> | Observable<boolean> {
-    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-      context.getHandler(),
-      context.getClass()
-    ])
-    if (isPublic) {
+    const isAuthNeeded = this.reflector.getAllAndOverride<boolean>(
+      IS_AUTH_NEEDED_KEY,
+      [context.getHandler(), context.getClass()]
+    )
+    if (!isAuthNeeded) {
       return true
     }
     return super.canActivate(context)

--- a/backend/src/common/decorator/auth-ignore.decorator.ts
+++ b/backend/src/common/decorator/auth-ignore.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common'
+
+export const IS_AUTH_NEEDED_KEY = 'auth-not-needed'
+export const AuthNotNeeded = () => SetMetadata(IS_AUTH_NEEDED_KEY, false)

--- a/backend/src/common/decorator/public.decorator.ts
+++ b/backend/src/common/decorator/public.decorator.ts
@@ -1,4 +1,0 @@
-import { SetMetadata } from '@nestjs/common'
-
-export const IS_PUBLIC_KEY = 'public'
-export const Public = () => SetMetadata(IS_PUBLIC_KEY, true)

--- a/backend/src/contest/contest.controller.ts
+++ b/backend/src/contest/contest.controller.ts
@@ -18,11 +18,11 @@ import {
 import { GroupMemberGuard } from 'src/group/guard/group-member.guard'
 import { ContestService } from './contest.service'
 import { Contest } from '@prisma/client'
-import { Public } from 'src/common/decorator/public.decorator'
+import { AuthNotNeeded } from 'src/common/decorator/auth-ignore.decorator'
 import { RolesGuard } from 'src/user/guard/roles.guard'
 
 @Controller('contest')
-@Public()
+@AuthNotNeeded()
 export class ContestController {
   constructor(private readonly contestService: ContestService) {}
 

--- a/backend/src/notice/notice.controller.ts
+++ b/backend/src/notice/notice.controller.ts
@@ -10,14 +10,14 @@ import {
 } from '@nestjs/common'
 import { NoticeService } from './notice.service'
 import { Notice } from '@prisma/client'
-import { Public } from 'src/common/decorator/public.decorator'
+import { AuthNotNeeded } from 'src/common/decorator/auth-ignore.decorator'
 import { RolesGuard } from 'src/user/guard/roles.guard'
 import { GroupMemberGuard } from 'src/group/guard/group-member.guard'
 import { UserNotice } from './interface/user-notice.interface'
 import { EntityNotExistException } from 'src/common/exception/business.exception'
 
 @Controller('notice')
-@Public()
+@AuthNotNeeded()
 export class PublicNoticeController {
   constructor(private readonly noticeService: NoticeService) {}
 

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -32,14 +32,14 @@ import { EmailAuthensticationPinDto } from './dto/email-auth-pin.dto'
 import { Request, Response } from 'express'
 import { UpdateUserEmailDto } from './dto/update-user-email.dto'
 import { AUTH_TYPE } from './constants/jwt.constants'
-import { Public } from '../common/decorator/public.decorator'
+import { AuthNotNeeded } from '../common/decorator/auth-ignore.decorator'
 
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Patch('/password-reset')
-  @Public()
+  @AuthNotNeeded()
   async updatePassword(
     @Body() newPasswordDto: NewPasswordDto,
     @Req() req: Request
@@ -57,7 +57,7 @@ export class UserController {
   }
 
   @Post('/sign-up')
-  @Public()
+  @AuthNotNeeded()
   async signUp(@Body() signUpDto: SignUpDto, @Req() req: Request) {
     try {
       await this.userService.signUp(req, signUpDto)
@@ -143,7 +143,7 @@ export class UserController {
 }
 
 @Controller('email-auth')
-@Public()
+@AuthNotNeeded()
 export class EmailAuthenticationController {
   constructor(private readonly userService: UserService) {}
 

--- a/backend/src/workbook/workbook.controller.ts
+++ b/backend/src/workbook/workbook.controller.ts
@@ -12,7 +12,7 @@ import { EntityNotExistException } from 'src/common/exception/business.exception
 import { RolesGuard } from 'src/user/guard/roles.guard'
 import { GroupMemberGuard } from '../group/guard/group-member.guard'
 import { Workbook } from '@prisma/client'
-import { Public } from 'src/common/decorator/public.decorator'
+import { AuthNotNeeded } from 'src/common/decorator/auth-ignore.decorator'
 
 @Controller('group/:groupId/workbook')
 @UseGuards(RolesGuard, GroupMemberGuard)
@@ -47,7 +47,7 @@ export class GroupWorkbookController {
 }
 
 @Controller('workbook')
-@Public()
+@AuthNotNeeded()
 export class PublicWorkbookController {
   constructor(private readonly workbookService: WorkbookService) {}
 


### PR DESCRIPTION
Closes #366 
### Description

- public.decorator.ts에 정의되어있었던 Public 데코레이터 이름을 AuthNotNeeded로 변경합니다.
  - Public은 '대중의', '대중을 위한', '공공의'라는 뜻을 가진 형용사입니다. (출처: 옥스포드 영한사전)
  - Authentication 유효성을 검증하는 기능과 데코레이터 이름이 일치하지 않아 혼란을 야기합니다.
- 파일 이름도 auth-ignore.decorator.ts로 변경합니다.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
