### PR TITLE
fix: specify output directory in nest-cli.json

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -2,7 +2,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["**/*.hbs", "**/*.png"],
+    "assets": [{ "include": "email/templates/**/*", "outDir": "dist/src" }],
+    "watchAssets": true,
     "plugins": ["@nestjs/swagger"]
   }
 }


### PR DESCRIPTION
Fixes #368 
### Description

- email template을 dist/src/email/templates에서 찾고 있는데 dist/email/templates에 복사되는 문제가 있었습니다.
- nest-cli.json에서 `"outDir": "dist/src"`옵션을 주어 해결했습니다.

![image](https://user-images.githubusercontent.com/64393421/216261792-a3638a97-2a3f-481a-af17-5462d6a1a59d.png)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
