### PR TITLE
fix(ci): lint pr message only on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         run: pnpm install
 
       - name: Lint pull request title
+        if: ${{ github.event_name == 'pull_request' }}
         run: echo ${{ github.event.pull_request.title }} | pnpm commitlint --verbose
 
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Lint pull request title
         if: ${{ github.event_name == 'pull_request' }}
-        run: echo ${{ github.event.pull_request.title }} | pnpm commitlint --verbose
+        run: echo "${{ github.event.pull_request.title }}" | pnpm commitlint --verbose
 
       - name: Lint
         run: pnpm lint


### PR DESCRIPTION
### Description

#192 에서 구현한 CI에서의 pull request 제목 lint가 main branch에 push되었을 경우에도 실행됩니다.
main branch에 push할 경우 pull request 제목이 존재하지 않아 CI가 실패합니다.

pull request에서만 해당 CI hook을 실행하도록 수정합니다.

참고: https://github.com/skkuding/next/actions/runs/4142147317/jobs/7162474079

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md)
- [x] Read the [Contributing Guidelines](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#pr-and-branch) and follow the [Commit Convention](https://github.com/skkuding/next/blob/main/CONTRIBUTING.md#commit-convention)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
